### PR TITLE
Added FlatDescription to extract/restore topics ACLs from cluster.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
     <testcontainers.version>1.13.0</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
     <confluent.version>5.5.0</confluent.version>
-    <confluent-ce.version>5.5.0-ce</confluent-ce.version>
+    <confluent-ce.version>5.5.1-ce</confluent-ce.version>
     <avro.version>1.9.2</avro.version>
     <jersey.version>2.22.2</jersey.version>
     <hamcrest.version>2.2</hamcrest.version>
@@ -442,22 +442,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-streams</artifactId>
-      <version>${kafka.version}</version>
-      <classifier>test</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-streams-test-utils</artifactId>
-      <version>${kafka.version}</version>
-    <scope>test</scope>
-            <classifier>test</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
-
       <classifier>test</classifier>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     <!-- dependencies -->
     <jackson.version>2.10.3</jackson.version>
-    <kafka.version>2.4.1</kafka.version>
+    <kafka.version>2.5.0</kafka.version>
     <log4j.version>2.13.3</log4j.version>
     <httpclient.version>4.5.11</httpclient.version>
     <zookeeper.version>3.5.7</zookeeper.version>
@@ -426,7 +426,7 @@
     <testcontainers.version>1.13.0</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
     <confluent.version>5.5.0</confluent.version>
-    <confluent-ce.version>5.5.1-ce</confluent-ce.version>
+    <confluent-ce.version>5.5.0-ce</confluent-ce.version>
     <avro.version>1.9.2</avro.version>
     <jersey.version>2.22.2</jersey.version>
     <hamcrest.version>2.2</hamcrest.version>
@@ -439,6 +439,26 @@
       <artifactId>jedis</artifactId>
       <version>${jedis.version}</version>
       <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams</artifactId>
+      <version>${kafka.version}</version>
+      <classifier>test</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams-test-utils</artifactId>
+      <version>${kafka.version}</version>
+    <scope>test</scope>
+            <classifier>test</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+
+      <classifier>test</classifier>
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>

--- a/src/main/java/com/purbon/kafka/topology/FDManager.java
+++ b/src/main/java/com/purbon/kafka/topology/FDManager.java
@@ -1,0 +1,485 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.model.FlatDescription;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.TopicDescription;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.common.acl.*;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourceType;
+
+public class FDManager {
+
+  interface TopicConfigUpdatePolicy {
+    List<AbstractAction> calcChanges(
+        String topicName, Map<String, String> currentConfig, Map<String, String> desiredConfig);
+  }
+
+  static class DoNothingPolicy implements TopicConfigUpdatePolicy {
+    @Override
+    public List<AbstractAction> calcChanges(
+        String topicName, Map<String, String> currentConfig, Map<String, String> desiredConfig) {
+      return Collections.EMPTY_LIST;
+    }
+  }
+
+  static class IncrementalUpdateNoCheck implements TopicConfigUpdatePolicy {
+    /**
+     * Incrementally applies the new settings from 'desiredConfig'.
+     *
+     * <p>Settings which are part of currentConfig but not of desiredConfig will not be changed.
+     *
+     * @param topicName
+     * @param currentConfig
+     * @param desiredConfig
+     * @return
+     */
+    @Override
+    public List<AbstractAction> calcChanges(
+        String topicName, Map<String, String> currentConfig, Map<String, String> desiredConfig) {
+      Map<String, String> updatedConfigs = new HashMap<>();
+      desiredConfig.forEach(
+          (dKey, dValue) -> {
+            if (!currentConfig.containsKey(dKey) || !currentConfig.get(dKey).equals(dValue)) {
+              updatedConfigs.put(dKey, dValue);
+            }
+          });
+      final IncrementallyUpdateTopicAction action =
+          new IncrementallyUpdateTopicAction(topicName, updatedConfigs);
+      return Collections.singletonList(action);
+    }
+  }
+
+  // called AbstractAction to prevent naming conflict
+  interface AbstractAction {
+    boolean run(AdminClient adminClient);
+  }
+
+  static class IncrementallyUpdateTopicAction implements AbstractAction {
+
+    final String topicName;
+    final Map<String, String> topicConfig;
+
+    IncrementallyUpdateTopicAction(String topicName, Map<String, String> topicConfig) {
+      this.topicName = topicName;
+      this.topicConfig = topicConfig;
+    }
+
+    @Override
+    public boolean run(AdminClient adminClient) {
+
+      Collection<AlterConfigOp> ops = new ArrayList<>();
+
+      topicConfig.forEach(
+          (k, v) -> {
+            ConfigEntry entry = new ConfigEntry(k, v);
+            AlterConfigOp op = new AlterConfigOp(entry, AlterConfigOp.OpType.SET);
+            ops.add(op);
+          });
+      Map<ConfigResource, Collection<AlterConfigOp>> stuff =
+          Collections.singletonMap(new ConfigResource(ConfigResource.Type.TOPIC, topicName), ops);
+
+      try {
+        adminClient.incrementalAlterConfigs(stuff).all().get();
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "Action: update settings for topic  " + topicName + " " + topicConfig;
+    }
+  }
+
+  // better replace this with an action which can delete a collection of topics?
+  static class DeleteTopicAction implements AbstractAction {
+
+    final String topicName;
+
+    public DeleteTopicAction(String topicName) {
+      this.topicName = topicName;
+    }
+
+    @Override
+    public boolean run(AdminClient adminClient) {
+      try {
+        adminClient.deleteTopics(Collections.singleton(topicName)).all().get();
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "Will delete topic " + topicName;
+    }
+  }
+
+  static class CreateAclsActions implements AbstractAction {
+
+    final Collection<TopologyAclBinding> aclsToCreate;
+
+    CreateAclsActions(Collection<TopologyAclBinding> aclsToCreate) {
+      this.aclsToCreate = aclsToCreate;
+    }
+
+    @Override
+    public boolean run(AdminClient adminClient) {
+      final Set<AclBinding> collect =
+          aclsToCreate.stream().map(TopologyAclBinding::toAclBinding).collect(Collectors.toSet());
+      try {
+        adminClient.createAcls(collect).all().get();
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "Action: create ACls " + aclsToCreate;
+    }
+  }
+
+  static class DeleteAclsActions implements AbstractAction {
+
+    final Collection<TopologyAclBinding> aclsToDelete;
+
+    DeleteAclsActions(Collection<TopologyAclBinding> aclsToDelete) {
+      this.aclsToDelete = aclsToDelete;
+    }
+
+    @Override
+    public boolean run(AdminClient adminClient) {
+      final Set<AclBindingFilter> collect =
+          aclsToDelete.stream()
+              .map(TopologyAclBinding::toAclBinding)
+              .map(AclBinding::toFilter)
+              .collect(Collectors.toSet());
+      try {
+        adminClient.deleteAcls(collect).all().get();
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "Action: delete ACls " + aclsToDelete;
+    }
+  }
+
+  static class CreateTopicsAction implements AbstractAction {
+
+    // TODO: clean up the logic for default replication.factor and num.partitions
+    String defaultNumPartitions = "6";
+    String defaultReplicationFactor = "3";
+
+    final Collection<TopicDescription> topicDescriptions;
+
+    CreateTopicsAction(Collection<TopicDescription> topicDescriptions) {
+      this.topicDescriptions = topicDescriptions;
+    }
+
+    @Override
+    public boolean run(AdminClient adminClient) {
+      final Set<NewTopic> newTopicConfigs =
+          topicDescriptions.stream()
+              .map(
+                  td -> {
+                    final Map<String, String> configs = td.getConfigs();
+                    Short replicationFactor =
+                        Short.valueOf(
+                            configs.getOrDefault(
+                                "default.replication.factor", defaultReplicationFactor));
+                    Integer numPartitions =
+                        Integer.valueOf(
+                            configs.getOrDefault("num.partitions", defaultNumPartitions));
+                    final NewTopic nt =
+                        new NewTopic(td.getName(), numPartitions, replicationFactor);
+                    nt.configs(configs);
+                    return nt;
+                  })
+              .collect(Collectors.toSet());
+      try {
+        adminClient.createTopics(newTopicConfigs).all().get();
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      final Set<String> topicNames =
+          topicDescriptions.stream().map(TopicDescription::getName).collect(Collectors.toSet());
+      return "Action: create topics " + topicNames;
+    }
+  }
+
+  public List<AbstractAction> generatePlan(
+      FlatDescription currentState,
+      FlatDescription desiredState,
+      boolean allowDeletes,
+      TopicConfigUpdatePolicy updatePolicy) {
+
+    List<AbstractAction> actions = new ArrayList<>();
+
+    System.out.println("removed: " + calculateRemovedTopics(currentState, desiredState));
+    System.out.println("added:" + calculateNewTopics(currentState, desiredState));
+    System.out.println("changed: " + calculateTopicConfigDiffs(currentState, desiredState));
+    if (allowDeletes) {
+      calculateRemovedTopics(currentState, desiredState)
+          .forEach(
+              topicName -> {
+                actions.add(new DeleteTopicAction(topicName));
+              });
+      final Set<TopologyAclBinding> aclBindingsToRemove =
+          calculateRemovedAcls(currentState, desiredState);
+      if (!aclBindingsToRemove.isEmpty()) {
+        actions.add(new DeleteAclsActions(aclBindingsToRemove));
+      }
+    }
+    final Set<TopicDescription> newTopicDescriptions =
+        calculateNewTopics(currentState, desiredState).stream()
+            .map(topicName -> desiredState.getTopics().get(topicName))
+            .collect(Collectors.toSet());
+    actions.add(new CreateTopicsAction(newTopicDescriptions));
+
+    calculateTopicConfigDiffs(currentState, desiredState)
+        .forEach(
+            topicName -> {
+              final List<AbstractAction> actionsForTopic =
+                  updatePolicy.calcChanges(
+                      topicName,
+                      currentState.getTopics().get(topicName).getConfigs(),
+                      desiredState.getTopics().get(topicName).getConfigs());
+              actions.addAll(actionsForTopic);
+            });
+
+    final Set<TopologyAclBinding> aclBindingsToAdd = calculateNewAcls(currentState, desiredState);
+    if (!aclBindingsToAdd.isEmpty()) {
+      actions.add(new CreateAclsActions(aclBindingsToAdd));
+    }
+    return actions;
+  }
+
+  /**
+   * Get all topicNames which are part of the currentState but are no longer part of the
+   * desiredState
+   *
+   * @param currentState
+   * @param desiredState
+   * @return
+   */
+  public Set<String> calculateRemovedTopics(
+      FlatDescription currentState, FlatDescription desiredState) {
+    final Set<String> currentTopicNames = extractTopicNames(currentState);
+    final Set<String> desiredTopicNames = extractTopicNames(desiredState);
+    currentTopicNames.removeAll(desiredTopicNames);
+    return currentTopicNames;
+  }
+
+  /**
+   * Get all topic names which are part of desiredState but are not currently in currentState.
+   *
+   * @param currentState
+   * @param desiredState
+   * @return
+   */
+  public Set<String> calculateNewTopics(
+      FlatDescription currentState, FlatDescription desiredState) {
+    final Set<String> currentTopicNames = extractTopicNames(currentState);
+    final Set<String> desiredTopicNames = extractTopicNames(desiredState);
+    desiredTopicNames.removeAll(currentTopicNames);
+    return desiredTopicNames;
+  }
+
+  /** @return */
+  public Set<String> calculateTopicConfigDiffs(
+      FlatDescription currentState, FlatDescription desiredState) {
+    final Set<String> currentTopicNames = extractTopicNames(currentState);
+    final Set<String> desiredTopicNames = extractTopicNames(desiredState);
+
+    desiredTopicNames.retainAll(
+        currentTopicNames); // now contains topic names which have not changed
+    final Set<String> topicNamesWithConfigChanges = new HashSet<>();
+    desiredTopicNames.forEach(
+        topicName -> {
+          final Map<String, String> currentConfig =
+              currentState.getTopics().get(topicName).getConfigs();
+          final Map<String, String> desiredConfig =
+              desiredState.getTopics().get(topicName).getConfigs();
+          if (!currentConfig.equals(desiredConfig)) {
+            topicNamesWithConfigChanges.add(topicName);
+          }
+        });
+    return topicNamesWithConfigChanges;
+  }
+
+  public Set<TopologyAclBinding> calculateNewAcls(
+      FlatDescription currentState, FlatDescription desiredState) {
+    final Set<TopologyAclBinding> currentACLs = extractAcls(currentState);
+    final Set<TopologyAclBinding> desiredACls = extractAcls(desiredState);
+    desiredACls.removeAll(currentACLs);
+    return desiredACls;
+  }
+
+  public Set<TopologyAclBinding> calculateRemovedAcls(
+      FlatDescription currentState, FlatDescription desiredState) {
+    final Set<TopologyAclBinding> currentAcls = extractAcls(currentState);
+    final Set<TopologyAclBinding> desiredAcls = extractAcls(desiredState);
+    currentAcls.removeAll(desiredAcls);
+    return currentAcls;
+  }
+
+  // returns a new Set containing the names of the topics in fd,
+  private Set<String> extractTopicNames(FlatDescription fd) {
+    return new HashSet<>(fd.getTopics().keySet());
+  }
+
+  // returns a new Set containing the ACL bindings from fd.
+  private Set<TopologyAclBinding> extractAcls(FlatDescription fd) {
+    return new HashSet<>(fd.getAclsBindings());
+  }
+
+  /**
+   * Converts a topology into the a FlatDescription
+   *
+   * @param topology
+   * @return
+   */
+  public FlatDescription compileTopology(Topology topology) {
+
+    final Map<String, TopicDescription> topicDescriptions = new HashMap<>();
+
+    topology.getProjects().stream()
+        .forEach(
+            project ->
+                project.getTopics().stream()
+                    .forEach(
+                        topic -> {
+                          final HashMap config = topic.getConfig();
+                          final String topicName = topic.toString();
+                          topicDescriptions.put(topicName, new TopicDescription(topicName, config));
+                        }));
+
+    Set<TopologyAclBinding> aclBindings = new HashSet<>();
+
+    // for each project in the topology, make ACLs
+    topology
+        .getProjects()
+        .forEach(
+            project -> {
+              aclBindings.addAll(getAclBindingForProject(project));
+            });
+
+    return new FlatDescription(aclBindings, topicDescriptions);
+  }
+
+  private Set<TopologyAclBinding> getAclBindingForProject(Project project) {
+
+    final Set<String> topicsInProject =
+        project.getTopics().stream().map(topic -> topic.toString()).collect(Collectors.toSet());
+    final Set<TopologyAclBinding> aclsForProject = new HashSet<>();
+
+    // deal with Producers: every producer in the project gets access to every topic
+    project
+        .getProducers()
+        .forEach(
+            producer -> {
+              final String principal = producer.getPrincipal();
+              final List<String> operations = Arrays.asList("WRITE", "DESCRIBE");
+              final Set<TopologyAclBinding> producerBindings =
+                  getLiteralBindingsFor(principal, ResourceType.TOPIC, operations, topicsInProject);
+              aclsForProject.addAll(producerBindings);
+            });
+
+    // deal with consumers: every consumer in the project gets access to every topic in the project:
+    project
+        .getConsumers()
+        .forEach(
+            consumer -> {
+              final String principal = consumer.getPrincipal();
+              final List<String> topicOperations = Arrays.asList("READ", "DESCRIBE");
+              final Set<TopologyAclBinding> consumerBindings =
+                  getLiteralBindingsFor(
+                      principal, ResourceType.TOPIC, topicOperations, topicsInProject);
+              aclsForProject.addAll(consumerBindings);
+
+              final String groupString = consumer.groupString();
+              final PatternType patternType =
+                  groupString.equals("*") ? PatternType.PREFIXED : PatternType.LITERAL;
+              aclsForProject.add(
+                  new TopologyAclBinding(
+                      ResourceType.GROUP,
+                      groupString,
+                      "*",
+                      "READ",
+                      principal,
+                      patternType.toString()));
+            });
+
+    // TODO: deal with connectors
+
+    project
+        .getStreams()
+        .forEach(
+            streamsApp -> {
+              final String principal = streamsApp.getPrincipal();
+              final List<String> readTopics = streamsApp.getTopics().get("read");
+              final List<String> writeTopics = streamsApp.getTopics().get("write");
+
+              aclsForProject.addAll(
+                  getLiteralBindingsFor(
+                      principal, ResourceType.TOPIC, Collections.singleton("READ"), readTopics));
+              aclsForProject.addAll(
+                  getLiteralBindingsFor(
+                      principal, ResourceType.TOPIC, Collections.singleton("WRITE"), writeTopics));
+              // lot's of stuff seems to be missing, for example consumer group
+              // TODO: add application_id to streams config
+              aclsForProject.add(
+                  new TopologyAclBinding(
+                      ResourceType.TOPIC,
+                      project.buildTopicPrefix(),
+                      "*",
+                      "ALL",
+                      principal,
+                      "PREFIXED"));
+            });
+    return aclsForProject;
+  }
+
+  private Set<TopologyAclBinding> getLiteralBindingsFor(
+      String principal,
+      ResourceType resourceType,
+      Collection<String> operations,
+      Collection<String> resourceNames) {
+    final Set<TopologyAclBinding> aclBindings = new HashSet<>();
+    resourceNames.forEach(
+        resourceName -> {
+          operations.forEach(
+              operation -> {
+                aclBindings.add(
+                    new TopologyAclBinding(
+                        resourceType, resourceName, "*", operation, principal, "LITERAL"));
+              });
+        });
+    return aclBindings;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/model/FlatDescription.java
+++ b/src/main/java/com/purbon/kafka/topology/model/FlatDescription.java
@@ -1,0 +1,99 @@
+package com.purbon.kafka.topology.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.config.ConfigResource;
+
+public class FlatDescription {
+  Set<TopologyAclBinding> aclsBindings;
+  Map<String, TopicDescription> topics;
+
+  // TODO: add RBAC role-bindings
+
+  @JsonCreator
+  public FlatDescription(
+      @JsonProperty("aclsBindings") Set<TopologyAclBinding> aclsBindings,
+      @JsonProperty("topics") Map<String, TopicDescription> topics) {
+    this.aclsBindings = aclsBindings;
+    this.topics = topics;
+  }
+
+  public Set<TopologyAclBinding> getAclsBindings() {
+    return aclsBindings;
+  }
+
+  public Map<String, TopicDescription> getTopics() {
+    return topics;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof FlatDescription)) return false;
+    FlatDescription that = (FlatDescription) o;
+    return Objects.equals(aclsBindings, that.aclsBindings) && Objects.equals(topics, that.topics);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(aclsBindings, topics);
+  }
+
+  public static FlatDescription extractFromCluster(AdminClient admin) {
+
+    try {
+      final ListTopicsResult listTopicsResult = admin.listTopics();
+      final Set<String> topicNames = listTopicsResult.names().get();
+
+      final Collection<ConfigResource> collect =
+          topicNames.stream()
+              .map(topicName -> new ConfigResource(ConfigResource.Type.TOPIC, topicName))
+              .collect(Collectors.toSet());
+
+      final DescribeConfigsResult describeConfigsResult = admin.describeConfigs(collect);
+      final Map<ConfigResource, Config> configResourceConfigMap = describeConfigsResult.all().get();
+
+      final Map<String, TopicDescription> tds = new HashMap<>();
+
+      configResourceConfigMap.forEach(
+          (configResource, config) -> {
+            Map<String, String> topicConfig = new HashMap<>();
+            config
+                .entries()
+                .forEach(
+                    configEntry -> {
+                      // TODO: discuss how to deal with default values
+                      if (!configEntry.isDefault())
+                        topicConfig.put(configEntry.name(), configEntry.value());
+                    });
+            final String topicName = configResource.name();
+            tds.put(topicName, new TopicDescription(topicName, topicConfig));
+          });
+
+      // now get ACL entries
+      Set<TopologyAclBinding> bindings = new HashSet<>();
+      try {
+        final DescribeAclsResult describeAclsResult = admin.describeAcls(AclBindingFilter.ANY);
+
+        final Collection<AclBinding> aclBindingsFromCluster = describeAclsResult.values().get();
+
+        aclBindingsFromCluster.forEach(b -> bindings.add(new TopologyAclBinding(b)));
+      } catch (ExecutionException e) {
+        // no ACLs present since security is diabled, just log the fact
+        System.out.println("security disabled, no ACLs found");
+      }
+      return new FlatDescription(bindings, tds);
+
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/model/TopicDescription.java
+++ b/src/main/java/com/purbon/kafka/topology/model/TopicDescription.java
@@ -1,0 +1,44 @@
+package com.purbon.kafka.topology.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
+
+public class TopicDescription {
+  String name;
+  Map<String, String> configs;
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, String> getConfigs() {
+    return configs;
+  }
+
+  @JsonCreator
+  public TopicDescription(
+      @JsonProperty("name") String name, @JsonProperty("configs") Map<String, String> configs) {
+    this.name = name;
+    this.configs = configs;
+  }
+
+  @Override
+  public String toString() {
+    return "TopicDescription{" + "name='" + name + '\'' + ", configs=" + configs + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TopicDescription)) return false;
+    TopicDescription that = (TopicDescription) o;
+    return Objects.equals(name, that.name) && Objects.equals(configs, that.configs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, configs);
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
@@ -3,6 +3,9 @@ package com.purbon.kafka.topology.roles;
 import java.util.Objects;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
@@ -78,6 +81,14 @@ public class TopologyAclBinding {
     this.operation = entry.operation().name();
     this.pattern = pattern.patternType().name();
     this.host = entry.host();
+  }
+
+  public AclBinding toAclBinding() {
+    // TODO: remove hard-coded allow and create field for it.
+    return new AclBinding(
+        new ResourcePattern(resourceType, resourceName, PatternType.fromString(pattern)),
+        new AccessControlEntry(
+            principal, host, AclOperation.fromString(operation), AclPermissionType.ALLOW));
   }
 
   public ResourceType getResourceType() {

--- a/src/main/java/com/purbon/kafka/topology/serdes/FlatDescriptionSerde.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/FlatDescriptionSerde.java
@@ -1,0 +1,69 @@
+package com.purbon.kafka.topology.serdes;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.purbon.kafka.topology.model.FlatDescription;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Converts a {@link com.purbon.kafka.topology.model.FlatDescription to and from JSON encoded
+ * strings.}
+ */
+public class FlatDescriptionSerde {
+
+  static final ObjectMapper mapper = new ObjectMapper();
+
+  static {
+    mapper.setVisibility(
+        mapper
+            .getSerializationConfig()
+            .getDefaultVisibilityChecker()
+            .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+            .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+            .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+            .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+  }
+
+  public static String convertToJsonString(FlatDescription fd) {
+    return convertToJsonString(fd, false);
+  }
+
+  public static String convertToJsonString(FlatDescription fd, boolean prettyPrint) {
+    try {
+      if (prettyPrint) {
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(fd);
+      } else {
+        return mapper.writeValueAsString(fd);
+      }
+    } catch (JsonProcessingException e) {
+      // TODO: add logging
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public static FlatDescription convertFromJsonString(String json) {
+    try {
+      return mapper.readValue(json, FlatDescription.class);
+    } catch (JsonProcessingException e) {
+      // TODO: add logging
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public static FlatDescription convertFromJsonFile(File file) {
+    try {
+      return mapper.readValue(file, FlatDescription.class);
+    } catch (JsonProcessingException e) {
+      // TODO: add logging
+      e.printStackTrace();
+    } catch (IOException e) {
+      // TODO: add proper logging
+      e.printStackTrace();
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/CLITest.java
+++ b/src/test/java/com/purbon/kafka/topology/CLITest.java
@@ -1,10 +1,6 @@
 package com.purbon.kafka.topology;
 
-import static com.purbon.kafka.topology.BuilderCLI.ADMIN_CLIENT_CONFIG_OPTION;
-import static com.purbon.kafka.topology.BuilderCLI.ALLOW_DELETE_OPTION;
-import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
-import static com.purbon.kafka.topology.BuilderCLI.DRY_RUN_OPTION;
-import static com.purbon.kafka.topology.BuilderCLI.QUIET_OPTION;
+import static com.purbon.kafka.topology.BuilderCLI.*;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -50,6 +46,8 @@ public class CLITest {
     config.put(ALLOW_DELETE_OPTION, "false");
     config.put(DRY_RUN_OPTION, "false");
     config.put(QUIET_OPTION, "false");
+    config.put(RECOVER_OPTION, null);
+    config.put(EXTRACT_OPTION, "false");
     config.put(ADMIN_CLIENT_CONFIG_OPTION, "topology-builder-sasl-plain.properties");
     cli.run(args);
 
@@ -73,6 +71,8 @@ public class CLITest {
     config.put(ALLOW_DELETE_OPTION, "false");
     config.put(DRY_RUN_OPTION, "true");
     config.put(QUIET_OPTION, "false");
+    config.put(RECOVER_OPTION, null);
+    config.put(EXTRACT_OPTION, "false");
     config.put(ADMIN_CLIENT_CONFIG_OPTION, "topology-builder-sasl-plain.properties");
     cli.run(args);
 

--- a/src/test/java/com/purbon/kafka/topology/FDManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/FDManagerTest.java
@@ -1,0 +1,167 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.model.FlatDescription;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.serdes.FlatDescriptionSerde;
+import com.purbon.kafka.topology.serdes.TopologySerdes;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.kafka.common.Node;
+import org.junit.Test;
+
+public class FDManagerTest {
+  @Test
+  public void test1() throws IOException {
+    final TopologySerdes topologySerde = new TopologySerdes();
+    final Topology topology = topologySerde.deserialise(new File("example/descriptor.yaml"));
+
+    final FDManager manager = new FDManager();
+
+    FlatDescription fd = manager.compileTopology(topology);
+    System.out.println(FlatDescriptionSerde.convertToJsonString(fd, true));
+  }
+
+  @Test
+  public void test2() throws IOException {
+    final String desc1 =
+        "---\n"
+            + "context: \"context\"\n"
+            + "company: \"company\"\n"
+            + "env: \"env\"\n"
+            + "source: \"source\"\n"
+            + "projects:\n"
+            + "  - name: \"projectA\"\n"
+            + "    consumers:\n"
+            + "      - principal: \"User:App0\"\n"
+            + "      - principal: \"User:App1\"\n"
+            + "    producers:\n"
+            + "      - principal: \"User:App3\"\n"
+            + "      - principal: \"User:App4\"\n"
+            + "    streams:\n"
+            + "      - principal: \"User:Streams0\"\n"
+            + "        topics:\n"
+            + "          read:\n"
+            + "            - \"topicA\"\n"
+            + "            - \"topicB\"\n"
+            + "          write:\n"
+            + "            - \"topicC\"\n"
+            + "            - \"topicD\"\n"
+            + "    connectors:\n"
+            + "      - principal: \"User:Connect1\"\n"
+            + "        group: \"group\"\n"
+            + "        status_topic: \"status\"\n"
+            + "        offset_topic: \"offset\"\n"
+            + "        configs_topic: \"configs\"\n"
+            + "        topics:\n"
+            + "          read:\n"
+            + "            - \"topicA\"\n"
+            + "            - \"topicB\"\n"
+            + "      - principal: \"User:Connect2\"\n"
+            + "        topics:\n"
+            + "          write:\n"
+            + "            - \"topicC\"\n"
+            + "            - \"topicD\"\n"
+            + "    topics:\n"
+            + "      - name: \"foo\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n"
+            + "      - name: \"bar\"\n"
+            + "        dataType: \"avro\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n"
+            + "  - name: \"projectB\"\n"
+            + "    topics:\n"
+            + "      - dataType: \"avro\"\n"
+            + "        name: \"bar\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n";
+
+    final String desc2 =
+        "---\n"
+            + "context: \"context\"\n"
+            + "company: \"company\"\n"
+            + "env: \"env\"\n"
+            + "source: \"source\"\n"
+            + "projects:\n"
+            + "  - name: \"projectA\"\n"
+            + "    consumers:\n"
+            + "      - principal: \"User:App0\"\n"
+            + "      - principal: \"User:App1\"\n"
+            + "    producers:\n"
+            + "      - principal: \"User:App3\"\n"
+            + "      - principal: \"User:App4\"\n"
+            + "    streams:\n"
+            + "      - principal: \"User:Streams0\"\n"
+            + "        topics:\n"
+            + "          read:\n"
+            + "            - \"topicA\"\n"
+            + "            - \"topicB\"\n"
+            + "          write:\n"
+            + "            - \"topicC\"\n"
+            + "            - \"topicD\"\n"
+            + "    connectors:\n"
+            + "      - principal: \"User:Connect1\"\n"
+            + "        group: \"group\"\n"
+            + "        status_topic: \"status\"\n"
+            + "        offset_topic: \"offset\"\n"
+            + "        configs_topic: \"configs\"\n"
+            + "        topics:\n"
+            + "          read:\n"
+            + "            - \"topicA\"\n"
+            + "            - \"topicB\"\n"
+            + "      - principal: \"User:Connect2\"\n"
+            + "        topics:\n"
+            + "          write:\n"
+            + "            - \"topicC\"\n"
+            + "            - \"topicD\"\n"
+            + "    topics:\n"
+            + "      - name: \"foo\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n"
+            + "      - name: \"bar\"\n"
+            + "        dataType: \"avro\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"2\"\n"
+            + "  - name: \"projectB\"\n"
+            + "    topics:\n"
+            + "      - dataType: \"avro\"\n"
+            + "        name: \"bar\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n"
+            + "      - dataType: \"avro\"\n"
+            + "        name: \"bar_new\"\n"
+            + "        config:\n"
+            + "          replication.factor: \"1\"\n"
+            + "          num.partitions: \"1\"\n";
+
+    final TopologySerdes topologySerde = new TopologySerdes();
+    final Topology topology1 = topologySerde.deserialise(desc1);
+    final Topology topology2 = topologySerde.deserialise(desc2);
+
+    final FDManager manager = new FDManager();
+
+    FlatDescription fd1 = manager.compileTopology(topology1);
+    FlatDescription fd2 = manager.compileTopology(topology2);
+
+    final List<FDManager.AbstractAction> abstractActions =
+        manager.generatePlan(fd1, fd2, true, new FDManager.DoNothingPolicy());
+    System.out.println(abstractActions);
+
+    final List<FDManager.AbstractAction> abstractActions2 =
+        manager.generatePlan(fd2, fd1, true, new FDManager.DoNothingPolicy());
+    System.out.println(abstractActions2);
+
+    Node node = new Node(0, "localhost", 9092);
+
+    // sadly, MockAdminClient has limited functionality at the moment
+    // MockAdminClient mockAdminClient = new MockAdminClient(Collections.singletonList(node), node);
+    // System.out.println(mockAdminClient.toString());
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/model/FlatDescriptionTest.java
+++ b/src/test/java/com/purbon/kafka/topology/model/FlatDescriptionTest.java
@@ -1,0 +1,36 @@
+package com.purbon.kafka.topology.model;
+
+import static org.junit.Assert.assertEquals;
+
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import com.purbon.kafka.topology.serdes.FlatDescriptionSerde;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.Test;
+
+public class FlatDescriptionTest {
+
+  @Test
+  public void jsonSerializationDeserialization() {
+    Set<TopologyAclBinding> aclBindings = new HashSet<>();
+    aclBindings.add(
+        new TopologyAclBinding(
+            ResourceType.TOPIC, "test-topic", "*", "WRITE", "User:alice", "LITERAL"));
+    aclBindings.add(
+        new TopologyAclBinding(
+            ResourceType.TOPIC, "test-topic", "*", "READ", "User:bob", "LITERAL"));
+
+    Map<String, TopicDescription> topics = new HashMap<>();
+    topics.put(
+        "test-topic", new TopicDescription("test-topic", Collections.singletonMap("hhh", "vvvv")));
+
+    final FlatDescription originalFlatDescription = new FlatDescription(aclBindings, topics);
+
+    final String serialized = FlatDescriptionSerde.convertToJsonString(originalFlatDescription);
+    final FlatDescription afterRoundtrip = FlatDescriptionSerde.convertFromJsonString(serialized);
+
+    assertEquals(originalFlatDescription, afterRoundtrip);
+  }
+
+}

--- a/src/test/java/com/purbon/kafka/topology/model/TopicDescriptionTest.java
+++ b/src/test/java/com/purbon/kafka/topology/model/TopicDescriptionTest.java
@@ -1,0 +1,6 @@
+package com.purbon.kafka.topology.model;
+
+public class TopicDescriptionTest {
+
+ 
+}

--- a/src/test/java/com/purbon/kafka/topology/roles/TopologyAclBindingTest.java
+++ b/src/test/java/com/purbon/kafka/topology/roles/TopologyAclBindingTest.java
@@ -1,0 +1,18 @@
+package com.purbon.kafka.topology.roles;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.Test;
+
+public class TopologyAclBindingTest {
+  @Test
+  public void fromKafkaAclBinding() {
+    TopologyAclBinding binding =
+        new TopologyAclBinding(
+            ResourceType.TOPIC, "test-topic", "hostname", "WRITE", "User:alice", "LITERAL");
+    TopologyAclBinding converted = new TopologyAclBinding(binding.toAclBinding());
+
+    assertEquals(binding, converted);
+  }
+}


### PR DESCRIPTION
* FlatDescription class as faithful description of cluster state (presently covers topics and ACLs only).

* added --extract and --restore options to BuilderCLI

* incorporated code to apply an FlatDescription to a cluster

* added code a compile a Topology to a FlatDescription (deals with producer/consumer/streams app only)