### PR TITLE
Enable JSON and YAML as Topology descriptor file formats.

### DIFF
--- a/docs/the-descriptor-files.rst
+++ b/docs/the-descriptor-files.rst
@@ -8,9 +8,15 @@ Because users might have complex deployments, the structure is flexible enough t
 The File format
 -----------
 
-Currently the tool supports reading YAML and JSON files. *Note* that all topologies will need to be using the same file format, a mixture is not supported.
+Currently the tool supports reading YAML and JSON files. **Note** that all topologies will need to be using the same file format, a mixture is not supported.
 
 In this guide we will use yaml as the core format, for JSON examples please refer to the examples directory.
+
+The file type is configured using the *topology.file.type* configuration variable.
+
+```
+topology.file.type=JSON
+```
 
 Getting started
 -----------

--- a/docs/the-descriptor-files.rst
+++ b/docs/the-descriptor-files.rst
@@ -8,7 +8,9 @@ Because users might have complex deployments, the structure is flexible enough t
 The File format
 -----------
 
-Currently the tool only supports reading YAML files. In the future this might change.
+Currently the tool supports reading YAML and JSON files. *Note* that all topologies will need to be using the same file format, a mixture is not supported.
+
+In this guide we will use yaml as the core format, for JSON examples please refer to the examples directory.
 
 Getting started
 -----------

--- a/example/descriptor.json
+++ b/example/descriptor.json
@@ -1,0 +1,20 @@
+{
+  "context": "team",
+  "projects": [{
+    "name": "foo",
+    "topics": [{
+      "dataType": "json",
+      "name": "foo",
+      "config": {
+        "replication.factor": "2",
+        "num.partitions": "3"
+      }
+    }, {
+      "name": "topic2",
+      "config": {
+        "replication.factor": "2",
+        "num.partitions": "3"
+      }
+    }]
+  }]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,16 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>5.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -502,16 +502,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-xml</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.woodstox</groupId>
-      <artifactId>woodstox-core</artifactId>
-      <version>5.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -24,6 +24,8 @@
 #ssl.keystore.type=PKCS12
 #ssl.key.password=test1234
 
+## Topology files type
+# topology.file.type=JSON
 
 ## SASL connection configuration
 #sasl.mechanism=PLAIN

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -24,7 +24,7 @@
 #ssl.keystore.type=PKCS12
 #ssl.key.password=test1234
 
-## Topology files type
+## Topology files type, the default value is YAML
 # topology.file.type=JSON
 
 ## SASL connection configuration

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -7,6 +7,7 @@ import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.serdes.TopologySerdes.FileType;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.HashMap;
@@ -58,6 +59,8 @@ public class TopologyBuilderConfig {
   static final String PROJECT_PREFIX_FORMAT_CONFIG = "topology.project.prefix.format";
   static final String TOPIC_PREFIX_SEPARATOR_CONFIG = "topology.topic.prefix.separator";
   static final String TOPOLOGY_VALIDATIONS_CONFIG = "topology.validations";
+
+  static final String TOPOLOGY_FILE_TYPE = "topology.file.type";
 
   private final Map<String, String> cliParams;
   private Config config;
@@ -269,5 +272,9 @@ public class TopologyBuilderConfig {
 
   public boolean isDryRun() {
     return Boolean.parseBoolean(cliParams.getOrDefault(DRY_RUN_OPTION, "false"));
+  }
+
+  public FileType getTopologyFileType() {
+    return config.getEnum(FileType.class, TOPOLOGY_FILE_TYPE);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/TopologyDescriptorBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyDescriptorBuilder.java
@@ -9,8 +9,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TopologyDescriptorBuilder {
+
+  private static final Logger LOGGER = LogManager.getLogger(TopologyDescriptorBuilder.class);
 
   public static Topology build(String fileOrDir) throws IOException {
     return build(fileOrDir, new TopologyBuilderConfig());
@@ -44,7 +48,7 @@ public class TopologyDescriptorBuilder {
                 try {
                   return parser.deserialise(path.toFile());
                 } catch (IOException e) {
-                  e.printStackTrace();
+                  LOGGER.error(e);
                   return new TopologyImpl();
                 }
               })

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.serdes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.purbon.kafka.topology.TopologyBuilderConfig;
@@ -16,24 +17,21 @@ public class TopologySerdes {
   private ObjectMapper mapper;
 
   public enum FileType {
-    JSON, YAML
+    JSON,
+    YAML,
+    XML
   }
+
   public TopologySerdes() {
     this(new TopologyBuilderConfig(), FileType.YAML);
   }
 
   public TopologySerdes(TopologyBuilderConfig config) {
-    this(config, FileType.YAML);
+    this(config, config.getTopologyFileType());
   }
 
   public TopologySerdes(TopologyBuilderConfig config, FileType type) {
-    mapper = type.equals(FileType.YAML) ?  new ObjectMapper(new YAMLFactory()) : new ObjectMapper();
-    SimpleModule module = new SimpleModule();
-    module.addDeserializer(Topology.class, new TopologyCustomDeserializer(config));
-    module.addDeserializer(TopicImpl.class, new TopicCustomDeserializer(config));
-    mapper.registerModule(module);
-    mapper.registerModule(new Jdk8Module());
-    mapper.findAndRegisterModules();
+    mapper = ObjectMapperFactory.build(type, config);
   }
 
   public Topology deserialise(File file) throws IOException {
@@ -46,5 +44,39 @@ public class TopologySerdes {
 
   public String serialise(Topology topology) throws JsonProcessingException {
     return mapper.writeValueAsString(topology);
+  }
+
+  private static class ObjectMapperFactory {
+
+    public static ObjectMapper build(FileType type, TopologyBuilderConfig config) {
+      ObjectMapper mapper;
+      if (type.equals(FileType.JSON)) {
+        mapper = buildAJsonObjectMapper();
+      } else if (type.equals(FileType.XML)) {
+        mapper = buildAnXMLObjectMapper();
+      } else {
+        mapper = buildAYamlObjectMapper();
+      }
+
+      SimpleModule module = new SimpleModule();
+      module.addDeserializer(Topology.class, new TopologyCustomDeserializer(config));
+      module.addDeserializer(TopicImpl.class, new TopicCustomDeserializer(config));
+      mapper.registerModule(module);
+      mapper.registerModule(new Jdk8Module());
+      mapper.findAndRegisterModules();
+      return mapper;
+    }
+
+    private static ObjectMapper buildAnXMLObjectMapper() {
+      return new XmlMapper();
+    }
+
+    private static ObjectMapper buildAYamlObjectMapper() {
+      return new ObjectMapper(new YAMLFactory());
+    }
+
+    private static ObjectMapper buildAJsonObjectMapper() {
+      return new ObjectMapper();
+    }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
@@ -15,12 +15,19 @@ public class TopologySerdes {
 
   private ObjectMapper mapper;
 
+  public enum FileType {
+    JSON, YAML
+  }
   public TopologySerdes() {
-    this(new TopologyBuilderConfig());
+    this(new TopologyBuilderConfig(), FileType.YAML);
   }
 
   public TopologySerdes(TopologyBuilderConfig config) {
-    mapper = new ObjectMapper(new YAMLFactory());
+    this(config, FileType.YAML);
+  }
+
+  public TopologySerdes(TopologyBuilderConfig config, FileType type) {
+    mapper = type.equals(FileType.YAML) ?  new ObjectMapper(new YAMLFactory()) : new ObjectMapper();
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Topology.class, new TopologyCustomDeserializer(config));
     module.addDeserializer(TopicImpl.class, new TopicCustomDeserializer(config));

--- a/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/TopologySerdes.java
@@ -3,7 +3,6 @@ package com.purbon.kafka.topology.serdes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.purbon.kafka.topology.TopologyBuilderConfig;
@@ -18,8 +17,7 @@ public class TopologySerdes {
 
   public enum FileType {
     JSON,
-    YAML,
-    XML
+    YAML
   }
 
   public TopologySerdes() {
@@ -51,11 +49,9 @@ public class TopologySerdes {
     public static ObjectMapper build(FileType type, TopologyBuilderConfig config) {
       ObjectMapper mapper;
       if (type.equals(FileType.JSON)) {
-        mapper = buildAJsonObjectMapper();
-      } else if (type.equals(FileType.XML)) {
-        mapper = buildAnXMLObjectMapper();
+        mapper = new ObjectMapper();
       } else {
-        mapper = buildAYamlObjectMapper();
+        mapper = new ObjectMapper(new YAMLFactory());
       }
 
       SimpleModule module = new SimpleModule();
@@ -65,18 +61,6 @@ public class TopologySerdes {
       mapper.registerModule(new Jdk8Module());
       mapper.findAndRegisterModules();
       return mapper;
-    }
-
-    private static ObjectMapper buildAnXMLObjectMapper() {
-      return new XmlMapper();
-    }
-
-    private static ObjectMapper buildAYamlObjectMapper() {
-      return new ObjectMapper(new YAMLFactory());
-    }
-
-    private static ObjectMapper buildAJsonObjectMapper() {
-      return new ObjectMapper();
     }
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,7 @@
 topology {
+  file {
+    type = "YAML"
+  }
   validations = []
   builder {
     access.control.class = "com.purbon.kafka.topology.roles.SimpleAclsProvider"

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -21,6 +21,7 @@ import com.purbon.kafka.topology.model.users.Producer;
 import com.purbon.kafka.topology.model.users.platform.ControlCenterInstance;
 import com.purbon.kafka.topology.model.users.platform.SchemaRegistryInstance;
 import com.purbon.kafka.topology.serdes.TopologySerdes;
+import com.purbon.kafka.topology.serdes.TopologySerdes.FileType;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -302,6 +303,18 @@ public class TopologySerdesTest {
     assertEquals(2, p.getTopics().size());
     assertEquals("source.contextOrg.foo.foo", p.getTopics().get(0).toString());
     assertEquals("source.contextOrg.foo.bar", p.getTopics().get(1).toString());
+  }
+
+  @Test
+  public void testJsonDescriptorFileSerdes() throws IOException, URISyntaxException {
+
+    TopologySerdes parser = new TopologySerdes(new TopologyBuilderConfig(), FileType.JSON);
+    URL descriptorWithOptionals = getClass().getResource("/descriptor.json");
+    Topology topology = parser.deserialise(Paths.get(descriptorWithOptionals.toURI()).toFile());
+
+    assertEquals(1, topology.getProjects().size());
+    assertEquals("foo", topology.getProjects().get(0).getName());
+    assertEquals(2, topology.getProjects().get(0).getTopics().size());
   }
 
   private List<Project> buildProjects() {

--- a/src/test/resources/descriptor.json
+++ b/src/test/resources/descriptor.json
@@ -1,0 +1,20 @@
+{
+  "context": "team",
+  "projects": [{
+    "name": "foo",
+    "topics": [{
+      "dataType": "json",
+      "name": "foo",
+      "config": {
+        "replication.factor": "2",
+        "num.partitions": "3"
+      }
+    }, {
+      "name": "topic2",
+      "config": {
+        "replication.factor": "2",
+        "num.partitions": "3"
+      }
+    }]
+  }]
+}


### PR DESCRIPTION
This pull request add code to handle other file descriptor formats such as:

- [x] JSON

*xml* for a future pull request

(*work in progress*, xml needs to redefine the custom parser)

*NOTE*: This future is for the upcoming 2.0 branch

closes #107 