### PR TITLE
Added test for list of topics as from properties file and examples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@ v1.0.0:
 * Extended the logging support to many components and classes in the KTB with the idea to support better troubleshooting. (Closes #101)
 * Add a filter to delete only topic configurations that are explicitly set, not the ones that use default values. (closes #99)
 * Fix a bug with wrongly set PatternType for Consumer group acls level. (closes #111)
-
+* Add test and documentation for list type config values as handled using the new config library.
+ 
 v1.0.0-rc2:
 * Check for required configuration values for the configuration of RBAC, if not present it raises a Configuration error
 * Update Log4j version to 2.13.3 to prevent CVE-2020-9488

--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -67,6 +67,21 @@ As a user you can customize:
 - **Property**: *topology.project.prefix.format*, to set the project level name format, it should be a subset of the previous one.
 - **Property**: *topology.topic.prefix.separator*, to select a custom separator between attributes.
 
+
+Internal topics prefixes
+-----------
+
+This is used to avoid deleting topics not controlled by topology builder.
+
+**Property**: *kafka.internal.topic.prefixes*
+**Default value**: "_"
+
+An example configuration might look like this:
+::
+    kafka.internal.topic.prefixes.0=_
+    kafka.internal.topic.prefixes.1=topicPrefixA
+    kafka.internal.topic.prefixes.2=topicPrefixB
+
 Topology level validations
 -----------
 
@@ -78,3 +93,10 @@ As a user you can list the validations to be applied using the configuration pro
 
 This property accepts the list of validations available in the class path.
 They will be applied in sequence as defined.
+
+An example configuration might look like this:
+::
+    topology.validations.0=topology.CamelCaseNameFormatValidation
+    topology.validations.1=topic.PartitionNumberValidation
+
+Users can pull custom validation available from the class path.

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -25,14 +25,14 @@
 #ssl.key.password=test1234
 
 
-# SASL connection configuration
+## SASL connection configuration
 #sasl.mechanism=PLAIN
 #sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
 #  username="kafka" \
 #  password="kafka";
 
 
-# RBAC access configuration
+## RBAC access configuration
 # topology.builder.mds.server = "http://localhost:8090"
 # topology.builder.mds.user = "mds"
 # topology.builder.mds.password = "mds-secret"

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -45,3 +45,12 @@
 # confluent.command.topic = _confluent-command
 # confluent.monitoring.topic = _confluent-monitoring
 # confluent.metrics.topic = _confluent-metrics
+
+## Filter internal topics to be excluded from the deletion process.
+# kafka.internal.topic.prefixes.0=_
+# kafka.internal.topic.prefixes.1=topicPrefixA
+# kafka.internal.topic.prefixes.2=topicPrefixB
+
+## Add custom validations for the topology files.
+# topology.validations.0=topology.CamelCaseNameFormatValidation
+# topology.validations.1=topic.PartitionNumberValidation

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
@@ -1,14 +1,17 @@
 package com.purbon.kafka.topology;
 
+import static com.purbon.kafka.topology.BuilderCLI.ADMIN_CLIENT_CONFIG_OPTION;
 import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.ACCESS_CONTROL_IMPLEMENTATION_CLASS;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.KAFKA_INTERNAL_TOPIC_PREFIXES;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_KAFKA_CLUSTER_ID_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_PASSWORD_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_SERVER;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_USER_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.PROJECT_PREFIX_FORMAT_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.TOPIC_PREFIX_FORMAT_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
@@ -18,6 +21,10 @@ import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.TopicSchemas;
 import com.purbon.kafka.topology.model.Topology;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -151,5 +158,27 @@ public class TopologyBuilderConfigTest {
 
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
     config.validateWith(topology);
+  }
+
+  @Test
+  public void testKafkaInternalTopicDefaultPrefix() throws URISyntaxException {
+    URL clientConfigURL = getClass().getResource("/client-config.properties");
+    String clientConfigFile = Paths.get(clientConfigURL.toURI()).toFile().toString();
+
+    cliOps.put(ADMIN_CLIENT_CONFIG_OPTION, clientConfigFile);
+
+    TopologyBuilderConfig config = TopologyBuilderConfig.build(cliOps);
+    assertThat(config.getKafkaInternalTopicPrefixes()).isEqualTo(Arrays.asList("_"));
+  }
+
+  @Test
+  public void testKafkaInternalTopicExtendedPrefix() throws URISyntaxException {
+    URL clientConfigURL = getClass().getResource("/config-internals-extended.properties");
+    String clientConfigFile = Paths.get(clientConfigURL.toURI()).toFile().toString();
+
+    cliOps.put(ADMIN_CLIENT_CONFIG_OPTION, clientConfigFile);
+
+    TopologyBuilderConfig config = TopologyBuilderConfig.build(cliOps);
+    assertThat(config.getKafkaInternalTopicPrefixes()).isEqualTo(Arrays.asList("_", "topicA", "topicB"));
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
@@ -4,7 +4,6 @@ import static com.purbon.kafka.topology.BuilderCLI.ADMIN_CLIENT_CONFIG_OPTION;
 import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.ACCESS_CONTROL_IMPLEMENTATION_CLASS;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG;
-import static com.purbon.kafka.topology.TopologyBuilderConfig.KAFKA_INTERNAL_TOPIC_PREFIXES;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_KAFKA_CLUSTER_ID_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_PASSWORD_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_SERVER;
@@ -179,6 +178,7 @@ public class TopologyBuilderConfigTest {
     cliOps.put(ADMIN_CLIENT_CONFIG_OPTION, clientConfigFile);
 
     TopologyBuilderConfig config = TopologyBuilderConfig.build(cliOps);
-    assertThat(config.getKafkaInternalTopicPrefixes()).isEqualTo(Arrays.asList("_", "topicA", "topicB"));
+    assertThat(config.getKafkaInternalTopicPrefixes())
+        .isEqualTo(Arrays.asList("_", "topicA", "topicB"));
   }
 }

--- a/src/test/resources/config-internals-extended.properties
+++ b/src/test/resources/config-internals-extended.properties
@@ -1,0 +1,10 @@
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+  username="kafka" \
+  password="kafka";
+schema.registry.url="http://localhost:8082"
+kafka.internal.topic.prefixes.0=_
+kafka.internal.topic.prefixes.1=topicA
+kafka.internal.topic.prefixes.2=topicB
+


### PR DESCRIPTION
This pull request added a couple of more test and examples for how to use the kafka internal topic prefix list since the introduction of the lightbend config library.

As a context, the former 

```java
kafka.internal.topic.prefixes="_,topicA,topicB"
```
format will no longer be supported, because this was doing an internal split by ",". Now the expected way of passing a list from the properties file would be by the spec:

```java
kafka.internal.topic.prefixes.0=_
kafka.internal.topic.prefixes.1=topicA
kafka.internal.topic.prefixes.2=topicB
```

pending:

- [ ] add docs on the configs _kafka.internal.topic.prefixes_ and _topology.validations_
- [ ] add examples for _kafka.internal.topic.prefixes_ and _topology.validations_ under the relevant directory.


closes #113 