### PR TITLE
Add an option of grouping ACLs for consumers and producers 

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -67,6 +67,18 @@ As a user you can customize:
 - **Property**: *topology.project.prefix.format*, to set the project level name format, it should be a subset of the previous one.
 - **Property**: *topology.topic.prefix.separator*, to select a custom separator between attributes.
 
+Optimised number of ACLs and RBAC bindings
+-----------
+
+This property is used to reduce the number of ACLs, or RBAC bindings, created. In the normal operational mode, the KTB, will create direct pair of bindings for each user and topic.
+However for some organisations, it might be enough, to create an optimised list by using prefixed bindings.
+
+**Property**: *topology.acls.optimized*
+**Default value**: "false"
+
+An example configuration might look like this:
+::
+    topology.acls.optimized=true
 
 Internal topics prefixes
 -----------

--- a/docs/futures/what-acl-management.rst
+++ b/docs/futures/what-acl-management.rst
@@ -40,6 +40,31 @@ Consumer definition with principal "User:App0" and without an specific consumer 
 
 Consumer definition with principal "User:App0" and consumer group name "foo".
 
+In the default mode the KTB will create dedicated ACL for each user and topic pair. For organisations that aim not to have dedicated pair or rules the KTB offer the option
+to optimise the number of ACLs using prefixed rules.
+
+The optimised ACLs/RBAC can be enabled using the *topology.acls.optimized* configuration property.
+
+Producers
+^^^^^^^^^^^
+As a user of KTB you can configure the required set of producers for your application.
+
+Producers have a principal.
+
+.. code-block:: YAML
+
+  ---
+    context: "context"
+    source: "source"
+    projects:
+      - name: "foo"
+        producers:
+          - principal: "User:App0"
+
+In the default mode the KTB will create dedicated ACL for each user and topic pair. For organisations that aim not to have dedicated pair or rules the KTB offer the option
+to optimise the number of ACLs using prefixed rules.
+
+The optimised ACLs/RBAC can be enabled using the *topology.acls.optimized* configuration property.
 
 Connectors
 ^^^^^^^^^^^

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -27,6 +27,9 @@
 ## Topology files type, the default value is YAML
 # topology.file.type=JSON
 
+## Use optimised access control bindings
+# topology.acls.optimized=true
+
 ## SASL connection configuration
 #sasl.mechanism=PLAIN
 #sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \

--- a/src/main/java/com/purbon/kafka/topology/BindingsBuilderProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/BindingsBuilderProvider.java
@@ -19,9 +19,11 @@ public interface BindingsBuilderProvider {
   List<TopologyAclBinding> buildBindingsForStreamsApp(
       String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics);
 
-  List<TopologyAclBinding> buildBindingsForConsumers(Collection<Consumer> consumers, String topic);
+  List<TopologyAclBinding> buildBindingsForConsumers(
+      Collection<Consumer> consumers, String resource, boolean prefixed);
 
-  List<TopologyAclBinding> buildBindingsForProducers(Collection<Producer> producers, String topic);
+  List<TopologyAclBinding> buildBindingsForProducers(
+      Collection<Producer> principals, String resource, boolean prefixed);
 
   default TopologyAclBinding setPredefinedRole(
       String principal, String predefinedRole, String topicPrefix) {

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -62,6 +62,8 @@ public class TopologyBuilderConfig {
 
   static final String TOPOLOGY_FILE_TYPE = "topology.file.type";
 
+  static final String OPTIMIZED_ACLS_CONFIG = "topology.acls.optimized";
+
   private final Map<String, String> cliParams;
   private Config config;
 
@@ -255,6 +257,10 @@ public class TopologyBuilderConfig {
 
   public String getTopicPrefixSeparator() {
     return config.getString(TOPIC_PREFIX_SEPARATOR_CONFIG);
+  }
+
+  public Boolean shouldOptimizeAcls() {
+    return config.getBoolean(OPTIMIZED_ACLS_CONFIG);
   }
 
   public List<String> getTopologyValidations() {

--- a/src/main/java/com/purbon/kafka/topology/actions/access/builders/BuildBindingsForConsumer.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/access/builders/BuildBindingsForConsumer.java
@@ -6,34 +6,36 @@ import com.purbon.kafka.topology.model.users.Consumer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class BuildBindingsForConsumer extends BaseAccessControlAction {
 
   private final String fullTopicName;
   private final List<Consumer> consumers;
   private final BindingsBuilderProvider builderProvider;
+  private boolean prefixed;
 
   public BuildBindingsForConsumer(
-      BindingsBuilderProvider builderProvider, List<Consumer> consumers, String fullTopicName) {
+      BindingsBuilderProvider builderProvider,
+      List<Consumer> consumers,
+      String fullTopicName,
+      boolean prefixed) {
     super();
     this.consumers = consumers;
     this.fullTopicName = fullTopicName;
     this.builderProvider = builderProvider;
+    this.prefixed = prefixed;
   }
 
   @Override
   protected void execute() {
-    bindings = builderProvider.buildBindingsForConsumers(consumers, fullTopicName);
+    bindings = builderProvider.buildBindingsForConsumers(consumers, fullTopicName, prefixed);
   }
 
   @Override
   protected Map<String, Object> props() {
-    List<String> principals =
-        consumers.stream().map(c -> c.getPrincipal()).collect(Collectors.toList());
     Map<String, Object> map = new HashMap<>();
     map.put("Operation", getClass().getName());
-    map.put("Principals", principals);
+    map.put("Principals", consumers);
     map.put("Topic", fullTopicName);
     return map;
   }

--- a/src/main/java/com/purbon/kafka/topology/actions/access/builders/BuildBindingsForProducer.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/access/builders/BuildBindingsForProducer.java
@@ -3,38 +3,39 @@ package com.purbon.kafka.topology.actions.access.builders;
 import com.purbon.kafka.topology.BindingsBuilderProvider;
 import com.purbon.kafka.topology.actions.BaseAccessControlAction;
 import com.purbon.kafka.topology.model.users.Producer;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class BuildBindingsForProducer extends BaseAccessControlAction {
 
   private final BindingsBuilderProvider builderProvider;
   private final List<Producer> producers;
   private final String fullTopicName;
+  private final boolean prefixed;
 
   public BuildBindingsForProducer(
-      BindingsBuilderProvider builderProvider, List<Producer> producers, String fullTopicName) {
+      BindingsBuilderProvider builderProvider,
+      List<Producer> producers,
+      String fullTopicName,
+      boolean prefixed) {
     super();
     this.builderProvider = builderProvider;
     this.producers = producers;
     this.fullTopicName = fullTopicName;
+    this.prefixed = prefixed;
   }
 
   @Override
-  protected void execute() throws IOException {
-    bindings = builderProvider.buildBindingsForProducers(producers, fullTopicName);
+  protected void execute() {
+    bindings = builderProvider.buildBindingsForProducers(producers, fullTopicName, prefixed);
   }
 
   @Override
   protected Map<String, Object> props() {
-    List<String> principals =
-        producers.stream().map(p -> p.getPrincipal()).collect(Collectors.toList());
     Map<String, Object> map = new HashMap<>();
     map.put("Operation", getClass().getName());
-    map.put("Principals", principals);
+    map.put("Principals", producers);
     map.put("Topic", fullTopicName);
     return map;
   }

--- a/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
@@ -88,14 +88,16 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
 
   @Override
   public List<TopologyAclBinding> buildBindingsForConsumers(
-      Collection<Consumer> consumers, String topic) {
-    return toList(consumers.stream().flatMap(consumer -> consumerAclsStream(consumer, topic)));
+      Collection<Consumer> consumers, String resource, boolean prefixed) {
+    return toList(
+        consumers.stream().flatMap(consumer -> consumerAclsStream(consumer, resource, prefixed)));
   }
 
   @Override
   public List<TopologyAclBinding> buildBindingsForProducers(
-      Collection<Producer> producers, String topic) {
-    return toList(producers.stream().flatMap(p -> producerAclsStream(p, topic)));
+      Collection<Producer> producers, String resource, boolean prefixed) {
+    return toList(
+        producers.stream().flatMap(producer -> producerAclsStream(producer, resource, prefixed)));
   }
 
   @Override
@@ -113,16 +115,15 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
     return bindingStream.map(TopologyAclBinding::new).collect(Collectors.toList());
   }
 
-  private Stream<AclBinding> producerAclsStream(Producer producer, String topic) {
+  private Stream<AclBinding> producerAclsStream(Producer producer, String topic, boolean prefixed) {
+    PatternType patternType = prefixed ? PatternType.PREFIXED : PatternType.LITERAL;
 
     List<AclBinding> bindings = new ArrayList<>();
 
     bindings.addAll(
         Arrays.asList(
-            buildTopicLevelAcl(
-                producer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.DESCRIBE),
-            buildTopicLevelAcl(
-                producer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.WRITE)));
+            buildTopicLevelAcl(producer.getPrincipal(), topic, patternType, AclOperation.DESCRIBE),
+            buildTopicLevelAcl(producer.getPrincipal(), topic, patternType, AclOperation.WRITE)));
 
     producer
         .getTransactionId()
@@ -154,16 +155,13 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
     return bindings.stream();
   }
 
-  private Stream<AclBinding> consumerAclsStream(Consumer consumer, String topic) {
+  private Stream<AclBinding> consumerAclsStream(Consumer consumer, String topic, boolean prefixed) {
+    PatternType patternType = prefixed ? PatternType.PREFIXED : PatternType.LITERAL;
     return Stream.of(
-        buildTopicLevelAcl(
-            consumer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.DESCRIBE),
-        buildTopicLevelAcl(consumer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.READ),
+        buildTopicLevelAcl(consumer.getPrincipal(), topic, patternType, AclOperation.DESCRIBE),
+        buildTopicLevelAcl(consumer.getPrincipal(), topic, patternType, AclOperation.READ),
         buildGroupLevelAcl(
-            consumer.getPrincipal(),
-            consumer.groupString(),
-            PatternType.LITERAL,
-            AclOperation.READ));
+            consumer.getPrincipal(), consumer.groupString(), patternType, AclOperation.READ));
   }
 
   private Stream<AclBinding> streamsAppStream(

--- a/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/rbac/RBACBindingsBuilder.java
@@ -119,21 +119,21 @@ public class RBACBindingsBuilder implements BindingsBuilderProvider {
 
   @Override
   public List<TopologyAclBinding> buildBindingsForConsumers(
-      Collection<Consumer> consumers, String topic) {
+      Collection<Consumer> consumers, String resource, boolean prefixed) {
+    String patternType = prefixed ? PREFIX : LITERAL;
     List<TopologyAclBinding> bindings = new ArrayList<>();
     consumers.forEach(
         consumer -> {
           TopologyAclBinding binding =
-              apiClient.bind(consumer.getPrincipal(), DEVELOPER_READ, topic, LITERAL);
+              apiClient.bind(consumer.getPrincipal(), DEVELOPER_READ, resource, patternType);
           bindings.add(binding);
-          String pattern = consumer.groupString().equals("*") ? PREFIX : LITERAL;
           binding =
               apiClient.bind(
                   consumer.getPrincipal(),
                   RESOURCE_OWNER,
                   consumer.groupString(),
                   "Group",
-                  pattern);
+                  LITERAL);
           bindings.add(binding);
         });
     return bindings;
@@ -141,12 +141,13 @@ public class RBACBindingsBuilder implements BindingsBuilderProvider {
 
   @Override
   public List<TopologyAclBinding> buildBindingsForProducers(
-      Collection<Producer> producers, String topic) {
+      Collection<Producer> producers, String resource, boolean prefixed) {
+    String patternType = prefixed ? PREFIX : LITERAL;
     List<TopologyAclBinding> bindings = new ArrayList<>();
     producers.forEach(
         producer -> {
           TopologyAclBinding binding =
-              apiClient.bind(producer.getPrincipal(), DEVELOPER_WRITE, topic, LITERAL);
+              apiClient.bind(producer.getPrincipal(), DEVELOPER_WRITE, resource, patternType);
           bindings.add(binding);
         });
     return bindings;

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,7 @@
 topology {
+  acls {
+    optimized = false
+  }
   file {
     type = "YAML"
   }

--- a/src/test/java/com/purbon/kafka/topology/AclsBindingsBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AclsBindingsBuilderTest.java
@@ -41,7 +41,7 @@ public class AclsBindingsBuilderTest {
     Consumer consumer = new Consumer("User:foo");
 
     List<TopologyAclBinding> aclBindings =
-        builder.buildBindingsForConsumers(Collections.singleton(consumer), "bar");
+        builder.buildBindingsForConsumers(Collections.singleton(consumer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(3);
     assertThat(aclBindings)
         .contains(buildTopicLevelAcl("User:foo", "bar", PatternType.LITERAL, AclOperation.READ));
@@ -56,7 +56,7 @@ public class AclsBindingsBuilderTest {
   public void testProducerAclsBuilder() {
     Producer producer = new Producer("User:foo");
     List<TopologyAclBinding> aclBindings =
-        builder.buildBindingsForProducers(Collections.singleton(producer), "bar");
+        builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(2);
     assertThat(aclBindings)
         .contains(buildTopicLevelAcl("User:foo", "bar", PatternType.LITERAL, AclOperation.WRITE));
@@ -70,7 +70,7 @@ public class AclsBindingsBuilderTest {
     Producer producer = new Producer("User:foo");
     producer.setTransactionId(Optional.of("1234"));
     List<TopologyAclBinding> aclBindings =
-        builder.buildBindingsForProducers(Collections.singleton(producer), "bar");
+        builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(5);
 
     assertThat(aclBindings)
@@ -104,7 +104,7 @@ public class AclsBindingsBuilderTest {
     Producer producer = new Producer("User:foo");
     producer.setIdempotence(Optional.of(true));
     List<TopologyAclBinding> aclBindings =
-        builder.buildBindingsForProducers(Collections.singleton(producer), "bar");
+        builder.buildBindingsForProducers(Collections.singleton(producer), "bar", false);
     assertThat(aclBindings.size()).isEqualTo(3);
 
     assertThat(aclBindings)

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -88,7 +88,7 @@ public class AccessControlManagerIT {
     // Crate an ACL outside of the control of the state manager.
     List<TopologyAclBinding> bindings =
         bindingsBuilder.buildBindingsForProducers(
-            Collections.singleton(new Producer("User:foo")), "bar");
+            Collections.singleton(new Producer("User:foo")), "bar", false);
     aclsProvider.createBindings(new HashSet<>(bindings));
 
     List<Consumer> consumers = new ArrayList<>();


### PR DESCRIPTION
This function is selected via configuration option.

tasks:

- [x] Grouping of ACLs for traditional ACLs
- [x] Grouping of ACLs for traditional for RBAC
- [x] Update documentation 

closes #80