### PR TITLE
Upgrade testcontainers to support recent Docker for Mac.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
     <commons.version>1.4</commons.version>
     <mockito.version>1.10.19</mockito.version>
     <junit.version>4.13.1</junit.version>
-    <testcontainers.version>1.13.0</testcontainers.version>
+    <testcontainers.version>1.15.0-rc2</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
     <confluent.version>5.5.0</confluent.version>
     <confluent-ce.version>5.5.1-ce</confluent-ce.version>

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class TopicManagerIT {
 
@@ -56,7 +57,7 @@ public class TopicManagerIT {
 
   @BeforeClass
   public static void setup() {
-    container = new KafkaContainer("5.5.0");
+    container = new KafkaContainer(TestcontainersConfiguration.getInstance().getKafkaDockerImageName().withTag("5.5.0"));
     container.start();
   }
 

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -11,12 +11,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class RedisBackendIT {
 
   @Rule
   public GenericContainer redis =
-      new GenericContainer<>("redis:5.0.3-alpine").withExposedPorts(6379);
+      new GenericContainer<>(DockerImageName.parse("redis:5.0.3-alpine")).withExposedPorts(6379);
 
   @Test
   public void testStoreAndFetch() throws IOException {


### PR DESCRIPTION
The testcontainers project was recently updated to be able to run on Macs with recent versions of Docker. See https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.0-rc2

This PR upgrades testcontainers to the fixed version.
