### PR TITLE
Make writing .cluster-state file idempotent

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -25,7 +25,7 @@ import com.purbon.kafka.topology.model.users.platform.SchemaRegistryInstance;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -136,7 +136,7 @@ public class AccessControlManager {
         .forEach(
             topic -> {
               final String fullTopicName = topic.toString();
-              Set<Consumer> consumers = new HashSet<>(topic.getConsumers());
+              Set<Consumer> consumers = new LinkedHashSet<>(topic.getConsumers());
               if (includeProjectLevel) {
                 consumers.addAll(project.getConsumers());
               }
@@ -146,7 +146,7 @@ public class AccessControlManager {
                         bindingsBuilder, new ArrayList<>(consumers), fullTopicName, false);
                 actions.add(action);
               }
-              Set<Producer> producers = new HashSet<>(topic.getProducers());
+              Set<Producer> producers = new LinkedHashSet<>(topic.getProducers());
               if (includeProjectLevel) {
                 producers.addAll(project.getProducers());
               }
@@ -173,13 +173,13 @@ public class AccessControlManager {
     List<Action> updateActions = new ArrayList<>();
 
     Set<TopologyAclBinding> allFinalBindings =
-        actions.stream().flatMap(actionApplyFunction()).collect(Collectors.toSet());
+        actions.stream().flatMap(actionApplyFunction()).collect(Collectors.toCollection(LinkedHashSet::new));
 
     // Diff of bindings, so we only create what is not already created in the cluster.
     Set<TopologyAclBinding> bindingsToBeCreated =
         allFinalBindings.stream()
             .filter(binding -> !bindings.contains(binding))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
 
     if (!bindingsToBeCreated.isEmpty()) {
       CreateBindings createBindings = new CreateBindings(controlProvider, bindingsToBeCreated);

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -4,7 +4,7 @@ import com.purbon.kafka.topology.backend.Backend;
 import com.purbon.kafka.topology.backend.FileBackend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -30,7 +30,7 @@ public class BackendController {
 
   public BackendController(Backend backend) {
     this.backend = backend;
-    this.bindings = new HashSet<>();
+    this.bindings = new LinkedHashSet<>();
   }
 
   public void add(List<TopologyAclBinding> bindings) {
@@ -44,7 +44,7 @@ public class BackendController {
   }
 
   public Set<TopologyAclBinding> getBindings() {
-    return new HashSet<>(bindings);
+    return new LinkedHashSet<>(bindings);
   }
 
   public void flushAndClose() {

--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -6,7 +6,7 @@ import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,7 +26,7 @@ public class ExecutionPlan {
       List<Action> plan, PrintStream outputStream, BackendController backendController) {
     this.plan = plan;
     this.outputStream = outputStream;
-    this.bindings = new HashSet<>();
+    this.bindings = new LinkedHashSet<>();
     this.backendController = backendController;
     if (backendController.size() > 0) {
       this.bindings.addAll(backendController.getBindings());

--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -74,7 +74,7 @@ public class ExecutionPlan {
           bindings =
               bindings.stream()
                   .filter(binding -> !action.getBindings().contains(binding))
-                  .collect(Collectors.toSet());
+                  .collect(Collectors.toCollection(LinkedHashSet::new));
         } else {
           bindings.addAll(action.getBindings());
         }

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -10,7 +10,7 @@ import java.io.RandomAccessFile;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -62,7 +62,7 @@ public class FileBackend implements Backend {
 
   public Set<TopologyAclBinding> load(URI uri) throws IOException {
     Path filePath = Paths.get(uri);
-    Set<TopologyAclBinding> bindings = new HashSet<>();
+    Set<TopologyAclBinding> bindings = new LinkedHashSet<>();
     BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()));
     String type = in.readLine();
     String line = null;


### PR DESCRIPTION
Running KTB twice with the same topology will still cause the .cluster-state file to change on every run. Because of usage of HashSet in a number of places the order of ACLs in the file will change on each run. This is undesired and especially a problem if using the FileBackend and wanting to push the file to some repo if changed.

Changed to LinkedHashSet to fix this.