### PR TITLE
ACL integration tests using testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -557,7 +557,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
     <commons.version>1.4</commons.version>
     <mockito.version>3.6.0</mockito.version>
     <junit.version>4.13.1</junit.version>
-    <testcontainers.version>1.15.0-rc2</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
     <jedis.version>3.2.0</jedis.version>
     <confluent.version>5.5.0</confluent.version>
     <confluent-ce.version>5.5.1-ce</confluent-ce.version>

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -80,7 +80,7 @@ public class AccessControlManagerIT {
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = container.getAdmin();
+    kafkaAdminClient = container.getAdminClient();
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
     adminClient.clearAcls();
     Files.deleteIfExists(Paths.get(".cluster-state"));

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -8,6 +8,7 @@ import com.purbon.kafka.topology.BackendController;
 import com.purbon.kafka.topology.ExecutionPlan;
 import com.purbon.kafka.topology.TopologyBuilderConfig;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextKafkaContainer;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -80,7 +80,7 @@ public class AccessControlManagerIT {
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = (AdminClient) container.getAdmin();
+    kafkaAdminClient = container.getAdmin();
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
     adminClient.clearAcls();
     Files.deleteIfExists(Paths.get(".cluster-state"));

--- a/src/test/java/com/purbon/kafka/topology/integration/KafkaTopologyBuilderIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/KafkaTopologyBuilderIT.java
@@ -7,6 +7,7 @@ import static com.purbon.kafka.topology.BuilderCLI.DRY_RUN_OPTION;
 import static com.purbon.kafka.topology.BuilderCLI.QUIET_OPTION;
 
 import com.purbon.kafka.topology.KafkaTopologyBuilder;
+import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextKafkaContainer;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;

--- a/src/test/java/com/purbon/kafka/topology/integration/KafkaTopologyBuilderIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/KafkaTopologyBuilderIT.java
@@ -12,9 +12,24 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class KafkaTopologyBuilderIT {
+
+  private static SaslPlaintextKafkaContainer container;
+
+  @BeforeClass
+  public static void setup() {
+    container = new SaslPlaintextKafkaContainer();
+    container.start();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    container.stop();
+  }
 
   @Test(expected = IOException.class)
   public void testSetupKafkaTopologyBuilderWithWrongCredentialsHC() throws Exception {
@@ -26,7 +41,7 @@ public class KafkaTopologyBuilderIT {
     String clientConfigFile = Paths.get(clientConfigURL.toURI()).toFile().toString();
 
     Map<String, String> config = new HashMap<>();
-    config.put(BROKERS_OPTION, "localhost:9092");
+    config.put(BROKERS_OPTION, container.getBootstrapServers());
     config.put(ALLOW_DELETE_OPTION, "false");
     config.put(DRY_RUN_OPTION, "false");
     config.put(QUIET_OPTION, "true");
@@ -45,7 +60,7 @@ public class KafkaTopologyBuilderIT {
     String clientConfigFile = Paths.get(clientConfigURL.toURI()).toFile().toString();
 
     Map<String, String> config = new HashMap<>();
-    config.put(BROKERS_OPTION, "localhost:9092");
+    config.put(BROKERS_OPTION, container.getBootstrapServers());
     config.put(ALLOW_DELETE_OPTION, "false");
     config.put(DRY_RUN_OPTION, "false");
     config.put(QUIET_OPTION, "true");

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -151,7 +151,7 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     return "127.0.0.1:" + ZOOKEEPER_PORT;
   }
 
-  public AdminClient getAdmin() {
+  public AdminClient getAdminClient() {
     return AdminClient.create(getClientConfig());
   }
 

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -8,10 +8,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
@@ -129,31 +125,11 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     return "127.0.0.1:" + ZOOKEEPER_PORT;
   }
 
-  public Map<String, Object> getAdminConfig() {
-    return getCommonConfig();
-  }
-
   public Admin getAdmin() {
-    return Admin.create(getAdminConfig());
+    return Admin.create(getConfig());
   }
 
-  public Map<String, Object> getProducerConfig() {
-    return getCommonConfig();
-  }
-
-  public Producer<?, ?> getProducer() {
-    return new KafkaProducer<>(getProducerConfig());
-  }
-
-  public Map<String, Object> getConsumerConfig() {
-    return getCommonConfig();
-  }
-
-  public Consumer<?, ?> getConsumer() {
-    return new KafkaConsumer<>(getConsumerConfig());
-  }
-
-  private Map<String, Object> getCommonConfig() {
+  private Map<String, Object> getConfig() {
     final Map<String, Object> map = new HashMap<>();
     map.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
     map.put("security.protocol", "SASL_PLAINTEXT");

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
@@ -151,8 +151,8 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     return "127.0.0.1:" + ZOOKEEPER_PORT;
   }
 
-  public Admin getAdmin() {
-    return Admin.create(getConfig());
+  public AdminClient getAdmin() {
+    return AdminClient.create(getConfig());
   }
 
   private Map<String, Object> getConfig() {

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -12,7 +12,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-/** @author <a href="mailto:shh@thathost.com">Sverre H. Huseby</a> */
 final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKafkaContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -16,14 +16,22 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
 
   private static final DockerImageName DEFAULT_IMAGE =
       DockerImageName.parse("confluentinc/cp-kafka").withTag("5.5.1");
+  private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
+  private static final String JAAS_CONFIG_FILE = "/tmp/broker_jaas.conf";
+  public static final String INTERNAL_LISTENER_NAME = "BROKER";
   public static final int KAFKA_PORT = 9092;
+  public static final int KAFKA_INTERNAL_PORT = 9093;
   public static final int ZOOKEEPER_PORT = 2181;
   private static final int PORT_NOT_ASSIGNED = -1;
-  /* Note difference with 0.0.0.0 and localhost: The former will be replaced by the container IP. */
+  /* Note difference between 0.0.0.0 and localhost: The former will be replaced by the container IP. */
   private static final String LISTENERS =
-      "SASL_PLAINTEXT://0.0.0.0:9092,INTERNAL://127.0.0.1:29092";
+      "SASL_PLAINTEXT://0.0.0.0:"
+          + KAFKA_PORT
+          + ","
+          + INTERNAL_LISTENER_NAME
+          + "://127.0.0.1:"
+          + KAFKA_INTERNAL_PORT;
   private int port = PORT_NOT_ASSIGNED;
-  private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
   public SaslPlaintextKafkaContainer() {
     this(DEFAULT_IMAGE);
@@ -40,8 +48,8 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     withEnv("KAFKA_LISTENERS", LISTENERS);
     withEnv(
         "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
-        "SASL_PLAINTEXT:SASL_PLAINTEXT,INTERNAL:SASL_PLAINTEXT");
-    withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL");
+        "SASL_PLAINTEXT:SASL_PLAINTEXT," + INTERNAL_LISTENER_NAME + ":SASL_PLAINTEXT");
+    withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", INTERNAL_LISTENER_NAME);
     withEnv("KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL", "PLAIN");
     withEnv("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN");
     withEnv(
@@ -53,7 +61,7 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     withEnv(
         "KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
         "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"kafka\" password=\"kafka\" user_kafka=\"kafka\" user_alice=\"alice-secret\" user_bob=\"bob-secret\"");
-    withEnv("KAFKA_OPTS", "-Djava.security.auth.login.config=/tmp/broker_jaas.conf");
+    withEnv("KAFKA_OPTS", "-Djava.security.auth.login.config=" + JAAS_CONFIG_FILE);
   }
 
   public String getBootstrapServers() {
@@ -79,15 +87,30 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
       return;
     }
     final String zookeeperConnect = startZookeeper();
+    uploadJaasConfig();
+    createStartupScript(zookeeperConnect);
+  }
+
+  private void uploadJaasConfig() {
+    final String jaas =
+        "KafkaServer { org.apache.kafka.common.security.plain.PlainLoginModule required "
+            + "username=\"kafka\" password=\"kafka\" "
+            + "user_kafka=\"kafka\" user_alice=\"alice-secret\" user_bob=\"bob-secret\"; };\n";
+    copyFileToContainer(
+        Transferable.of(jaas.getBytes(StandardCharsets.UTF_8), 0644), JAAS_CONFIG_FILE);
+  }
+
+  private void createStartupScript(final String zookeeperConnect) {
+    final String listeners = getEnvMap().get("KAFKA_LISTENERS");
+    if (listeners == null) {
+      throw new RuntimeException("Need environment variable KAFKA_LISTENERS");
+    }
     final String advertisedListeners =
-        LISTENERS
-            .replaceAll(":" + KAFKA_PORT, ":" + port)
+        listeners
+            .replaceAll(":" + KAFKA_PORT, ":" + getMappedPort(KAFKA_PORT))
             .replaceAll("0\\.0\\.0\\.0", getContainerIpAddress());
-    final String command =
+    final String starterScript =
         "#!/bin/bash\n"
-            + "cat > /tmp/broker_jaas.conf <<EOT\n"
-            + "KafkaServer { org.apache.kafka.common.security.plain.PlainLoginModule required username=\"kafka\" password=\"kafka\" user_kafka=\"kafka\" user_alice=\"alice-secret\" user_bob=\"bob-secret\"; };\n"
-            + "EOT\n"
             + "export KAFKA_ZOOKEEPER_CONNECT='"
             + zookeeperConnect
             + "'\n"
@@ -98,7 +121,7 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
             + "/etc/confluent/docker/configure\n"
             + "/etc/confluent/docker/launch\n";
     copyFileToContainer(
-        Transferable.of(command.getBytes(StandardCharsets.UTF_8), 0755), STARTER_SCRIPT);
+        Transferable.of(starterScript.getBytes(StandardCharsets.UTF_8), 0755), STARTER_SCRIPT);
   }
 
   private String startZookeeper() {

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -1,0 +1,166 @@
+package com.purbon.kafka.topology.integration;
+
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+/** @author <a href="mailto:shh@thathost.com">Sverre H. Huseby</a> */
+final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKafkaContainer> {
+
+  private static final DockerImageName DEFAULT_IMAGE =
+      DockerImageName.parse("confluentinc/cp-kafka").withTag("6.0.0");
+  public static final int KAFKA_PORT = 9092;
+  public static final int ZOOKEEPER_PORT = 2181;
+  private static final int PORT_NOT_ASSIGNED = -1;
+  /* Note difference with 0.0.0.0 and localhost: The former will be replaced by the container IP. */
+  private static final String LISTENERS =
+      "SASL_PLAINTEXT://0.0.0.0:9092,INTERNAL://127.0.0.1:29092";
+  private int port = PORT_NOT_ASSIGNED;
+  private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
+
+  public SaslPlaintextKafkaContainer() {
+    this(DEFAULT_IMAGE);
+  }
+
+  public SaslPlaintextKafkaContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
+    withExposedPorts(KAFKA_PORT, ZOOKEEPER_PORT);
+    withEnv("KAFKA_BROKER_ID", "1");
+    withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
+    withEnv("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", "1");
+    withEnv("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "");
+    withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+    withEnv("KAFKA_LISTENERS", LISTENERS);
+    withEnv(
+        "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+        "SASL_PLAINTEXT:SASL_PLAINTEXT,INTERNAL:SASL_PLAINTEXT");
+    withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL");
+    withEnv("KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL", "PLAIN");
+    withEnv("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN");
+    withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer");
+    withEnv("KAFKA_SUPER_USERS", "User:kafka");
+    withEnv(
+        "KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"kafka\" password=\"kafka\" user_kafka=\"kafka\" user_alice=\"alice-secret\" user_bob=\"bob-secret\"");
+    withEnv("KAFKA_OPTS", "-Djava.security.auth.login.config=/tmp/broker_jaas.conf");
+  }
+
+  public String getBootstrapServers() {
+    if (port == PORT_NOT_ASSIGNED) {
+      throw new IllegalStateException("You should start Kafka container first");
+    }
+    return String.format("%s:%s", getHost(), port);
+  }
+
+  @Override
+  protected void doStart() {
+    withCommand(
+        "sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+    super.doStart();
+  }
+
+  @Override
+  protected void containerIsStarting(
+      final InspectContainerResponse containerInfo, final boolean reused) {
+    super.containerIsStarting(containerInfo, reused);
+    port = getMappedPort(KAFKA_PORT);
+    if (reused) {
+      return;
+    }
+    final String zookeeperConnect = startZookeeper();
+    final String advertisedListeners =
+        LISTENERS
+            .replaceAll(":" + KAFKA_PORT, ":" + port)
+            .replaceAll("0\\.0\\.0\\.0", getContainerIpAddress());
+    final String command =
+        "#!/bin/bash\n"
+            + "cat > /tmp/broker_jaas.conf <<EOT\n"
+            + "KafkaServer { org.apache.kafka.common.security.plain.PlainLoginModule required username=\"kafka\" password=\"kafka\" user_kafka=\"kafka\" user_alice=\"alice-secret\" user_bob=\"bob-secret\"; };\n"
+            + "EOT\n"
+            + "export KAFKA_ZOOKEEPER_CONNECT='"
+            + zookeeperConnect
+            + "'\n"
+            + "export KAFKA_ADVERTISED_LISTENERS='"
+            + advertisedListeners
+            + "'\n"
+            + ". /etc/confluent/docker/bash-config\n"
+            + "/etc/confluent/docker/configure\n"
+            + "/etc/confluent/docker/launch\n";
+    copyFileToContainer(
+        Transferable.of(command.getBytes(StandardCharsets.UTF_8), 0755), STARTER_SCRIPT);
+  }
+
+  private String startZookeeper() {
+    final ExecCreateCmdResponse execCreateCmdResponse =
+        dockerClient
+            .execCreateCmd(getContainerId())
+            .withCmd(
+                "sh",
+                "-c",
+                "echo '*** Starting Zookeeper'\n"
+                    + "printf 'clientPort="
+                    + ZOOKEEPER_PORT
+                    + "\n"
+                    + "dataDir=/var/lib/zookeeper/data\ndataLogDir=/var/lib/zookeeper/log' > zookeeper.properties\n"
+                    + "zookeeper-server-start zookeeper.properties\n")
+            .withAttachStderr(true)
+            .withAttachStdout(true)
+            .exec();
+    try {
+      dockerClient
+          .execStartCmd(execCreateCmdResponse.getId())
+          .start()
+          .awaitStarted(10, TimeUnit.SECONDS);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    return "127.0.0.1:" + ZOOKEEPER_PORT;
+  }
+
+  public Map<String, Object> getAdminConfig() {
+    return getCommonConfig();
+  }
+
+  public Admin getAdmin() {
+    return Admin.create(getAdminConfig());
+  }
+
+  public Map<String, Object> getProducerConfig() {
+    return getCommonConfig();
+  }
+
+  public Producer<?, ?> getProducer() {
+    return new KafkaProducer<>(getProducerConfig());
+  }
+
+  public Map<String, Object> getConsumerConfig() {
+    return getCommonConfig();
+  }
+
+  public Consumer<?, ?> getConsumer() {
+    return new KafkaConsumer<>(getConsumerConfig());
+  }
+
+  private Map<String, Object> getCommonConfig() {
+    final Map<String, Object> map = new HashMap<>();
+    map.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
+    map.put("security.protocol", "SASL_PLAINTEXT");
+    map.put("sasl.mechanism", "PLAIN");
+    map.put(
+        "sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"kafka\" password=\"kafka\";");
+    return map;
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -152,10 +152,10 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
   }
 
   public AdminClient getAdmin() {
-    return AdminClient.create(getConfig());
+    return AdminClient.create(getClientConfig());
   }
 
-  private Map<String, Object> getConfig() {
+  private Map<String, Object> getClientConfig() {
     final Map<String, Object> map = new HashMap<>();
     map.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
     map.put("security.protocol", "SASL_PLAINTEXT");

--- a/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/SaslPlaintextKafkaContainer.java
@@ -15,7 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKafkaContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =
-      DockerImageName.parse("confluentinc/cp-kafka").withTag("6.0.0");
+      DockerImageName.parse("confluentinc/cp-kafka").withTag("5.5.1");
   public static final int KAFKA_PORT = 9092;
   public static final int ZOOKEEPER_PORT = 2181;
   private static final int PORT_NOT_ASSIGNED = -1;
@@ -44,7 +44,11 @@ final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKa
     withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL");
     withEnv("KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL", "PLAIN");
     withEnv("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN");
-    withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer");
+    withEnv(
+        "KAFKA_AUTHORIZER_CLASS_NAME",
+        dockerImageName.getVersionPart().compareTo("6") >= 0
+            ? "kafka.security.authorizer.AclAuthorizer"
+            : "kafka.security.auth.SimpleAclAuthorizer");
     withEnv("KAFKA_SUPER_USERS", "User:kafka");
     withEnv(
         "KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -64,7 +64,7 @@ public class TopicManagerIT {
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = container.getAdmin();
+    kafkaAdminClient = container.getAdminClient();
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
 
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -24,12 +24,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
@@ -42,12 +40,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class TopicManagerIT {
 
-  private static KafkaContainer container;
+  private static SaslPlaintextKafkaContainer container;
   private TopicManager topicManager;
   private AdminClient kafkaAdminClient;
 
@@ -57,9 +53,7 @@ public class TopicManagerIT {
 
   @BeforeClass
   public static void setup() {
-    container =
-        new KafkaContainer(
-            TestcontainersConfiguration.getInstance().getKafkaDockerImageName().withTag("5.5.0"));
+    container = new SaslPlaintextKafkaContainer();
     container.start();
   }
 
@@ -70,7 +64,7 @@ public class TopicManagerIT {
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = AdminClient.create(config());
+    kafkaAdminClient = (AdminClient) container.getAdmin();
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
 
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
@@ -340,12 +334,5 @@ public class TopicManagerIT {
     assertEquals(topicsCount, nonInternalTopics.size());
 
     assertTrue("Internal topics not found", isInternal);
-  }
-
-  private Properties config() {
-    Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
-    props.put(AdminClientConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
-    return props;
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -64,7 +64,7 @@ public class TopicManagerIT {
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = (AdminClient) container.getAdmin();
+    kafkaAdminClient = container.getAdmin();
     TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
 
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -7,6 +7,7 @@ import com.purbon.kafka.topology.BackendController;
 import com.purbon.kafka.topology.ExecutionPlan;
 import com.purbon.kafka.topology.TopicManager;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextKafkaContainer;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopicImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextKafkaContainer.java
@@ -1,4 +1,4 @@
-package com.purbon.kafka.topology.integration;
+package com.purbon.kafka.topology.integration.containerutils;
 
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -12,7 +12,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-final class SaslPlaintextKafkaContainer extends GenericContainer<SaslPlaintextKafkaContainer> {
+public final class SaslPlaintextKafkaContainer
+    extends GenericContainer<SaslPlaintextKafkaContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =
       DockerImageName.parse("confluentinc/cp-kafka").withTag("5.5.1");

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextKafkaContainer.java
@@ -16,7 +16,7 @@ public final class SaslPlaintextKafkaContainer
     extends GenericContainer<SaslPlaintextKafkaContainer> {
 
   private static final DockerImageName DEFAULT_IMAGE =
-      DockerImageName.parse("confluentinc/cp-kafka").withTag("5.5.1");
+      DockerImageName.parse("confluentinc/cp-kafka").withTag("5.5.0");
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
   private static final String JAAS_CONFIG_FILE = "/tmp/broker_jaas.conf";
   public static final String INTERNAL_LISTENER_NAME = "BROKER";


### PR DESCRIPTION
I saw that one integration test used KafkaContainer, while others assumably rely on a local Kafka to have been started manually. I thought it would be a good idea to be able to run all the integration tests using testcontainers, and I started with rewriting the tests for ACLs.

The SaslPlaintextKafkaContainer is based on the original KafkaContainers, but modified to support 6.0.0 from Confluent, and to run with SASL_PLAINTEXT natively.

I don't know if you want this change, but...