### PR TITLE
 Managed principals using topology Builder, include support for ccloud CLI

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -1,7 +1,7 @@
 name: Artifacts Builder
 on:
   schedule:
-    - cron: '* 0 * * *'
+    - cron: '0 0 * * *'
   push:
     branches:
       - master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Docker publish latest
 on:
   schedule:
-    - cron: '* 0 * * *'
+    - cron: '0 0 * * *'
 jobs:
   ktb_build:
     name: Build docker image

--- a/docs/futures/what-principal-management.rst
+++ b/docs/futures/what-principal-management.rst
@@ -1,0 +1,66 @@
+Managing Principals
+*******************************
+
+One of the common actions required when managing a cluster is the operation of principals (aka Users in kafka).
+The KTB can help you manage this principals by parsing the involved topologies.
+
+*NOTE* This feature is currently experimental, please use it with care and let us know anything that is missing.
+
+How does it work
+-----------
+
+As this feature is considered experimental for now, the reader should first enable it, this is done by adding the _topology.features.experimental_
+property in the configuration.
+
+
+.. code-block:: bash
+
+  topology.features.experimental=true (by default all experimental features are disabled)
+
+Once enabled, this feature will run in between the TopicManager and the BindingsManager, so right before the Bindings are created all required
+principals are present in the cluster.
+
+This process is done by parsing the topology description and extracting the principals, once done the tool will calculate which principals are
+required to be create and which ones are no longer necessary and can be disabled. For sure always if the related delete option is enabled.
+
+Principals Manager Providers
+-----------
+
+As a user of KTB you can select witch providers to use, they could be for example Confluent Cloud or SASL/SCRAM (once `#2 <https://github.com/kafka-ops/kafka-topology-builder/issues/2>`_ is implemented),
+the tool will contact the server and manage the user creation.
+
+In the current version you can only use the Confluent Cloud provider.
+
+Confluent Cloud Provider
+-----------
+
+If the reader is using the Confluent Cloud, you can manage the principals described in the Topology.
+This operations are dependant on the *ccloud* CLI, as a user you should have this tool available in your system.
+
+Another requirement is you should be logged in more details `here <https://docs.confluent.io/ccloud-cli/current/command-reference/ccloud_login.html>`_.
+Once this is done, the KTB will rely on CLI to manage the principals.
+
+Enabling principal translation
+-----------
+
+As a user of KTB with Confluent Cloud, you can chose to use the Service Account ID or the Service Account Name as a label describing your user.
+If you want the users to be managed by Kafka Topology Builder you have to use the principals by your Service Account name, the Topology
+will look like this:
+
+.. code-block:: YAML
+
+  ---
+    context: "context"
+    source: "source"
+    projects:
+      - name: "foo"
+        consumers:
+          - principal: "User:ApplicationName"
+
+internally this would be registered in Confluent Cloud and use internally the Service Account ID for managing all required ACLs.
+
+As this is an experimental feature you will be required to enable it.
+
+.. code-block:: bash
+
+  topology.translation.principal.enabled=true (by default all experimental features are disabled)

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProviderFactory.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProviderFactory.java
@@ -6,12 +6,14 @@ import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_USER_CONFIG;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.RBAC_ACCESS_CONTROL_CLASS;
 
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.api.ccloud.CCloudCLI;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.MDSApiClientBuilder;
 import com.purbon.kafka.topology.roles.RBACProvider;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
 import com.purbon.kafka.topology.roles.acls.AclsBindingsBuilder;
 import com.purbon.kafka.topology.roles.rbac.RBACBindingsBuilder;
+import com.purbon.kafka.topology.utils.CCloudUtils;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 
@@ -56,9 +58,13 @@ public class AccessControlProviderFactory {
 
   public BindingsBuilderProvider builder() throws IOException {
     String accessControlClass = config.getAccessControlClassName();
+
+    CCloudCLI cCloudApi = new CCloudCLI();
+    CCloudUtils cCloudUtils = new CCloudUtils(cCloudApi, config);
+
     try {
       if (accessControlClass.equalsIgnoreCase(ACCESS_CONTROL_DEFAULT_CLASS)) {
-        return new AclsBindingsBuilder(config);
+        return new AclsBindingsBuilder(config, cCloudUtils);
       } else if (accessControlClass.equalsIgnoreCase(RBAC_ACCESS_CONTROL_CLASS)) {
         MDSApiClient apiClient = apiClientLogIn();
         apiClient.authenticate();

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.backend.Backend;
 import com.purbon.kafka.topology.backend.FileBackend;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.HashSet;
@@ -23,6 +24,7 @@ public class BackendController {
 
   private final Backend backend;
   private Set<TopologyAclBinding> bindings;
+  private Set<ServiceAccount> serviceAccounts;
 
   public BackendController() {
     this(new FileBackend());
@@ -31,6 +33,7 @@ public class BackendController {
   public BackendController(Backend backend) {
     this.backend = backend;
     this.bindings = new HashSet<>();
+    this.serviceAccounts = new HashSet<>();
   }
 
   public void add(List<TopologyAclBinding> bindings) {
@@ -38,9 +41,18 @@ public class BackendController {
     this.bindings.addAll(bindings);
   }
 
+  public void addServiceAccounts(Set<ServiceAccount> serviceAccounts) {
+    LOGGER.debug(String.format("Adding Service Accounts %s to the backend", serviceAccounts));
+    this.serviceAccounts.addAll(serviceAccounts);
+  }
+
   public void add(TopologyAclBinding binding) {
     LOGGER.debug(String.format("Adding binding %s to the backend", binding));
     this.bindings.add(binding);
+  }
+
+  public Set<ServiceAccount> getServiceAccounts() {
+    return new HashSet<>(serviceAccounts);
   }
 
   public Set<TopologyAclBinding> getBindings() {
@@ -52,21 +64,25 @@ public class BackendController {
     backend.createOrOpen(Mode.TRUNCATE);
     backend.saveType(STORE_TYPE);
     backend.saveBindings(bindings);
+    backend.saveType("ServiceAccounts");
+    backend.saveAccounts(serviceAccounts);
     backend.close();
   }
 
   public void load() throws IOException {
     LOGGER.debug(String.format("Loading data from the backend at %s", backend.getClass()));
     backend.createOrOpen();
-    bindings.addAll(backend.load());
+    bindings.addAll(backend.loadBindings());
+    serviceAccounts.addAll(backend.loadServiceAccounts());
   }
 
   public void reset() {
     LOGGER.debug("Reset the bindings cache");
     bindings.clear();
+    serviceAccounts.clear();
   }
 
   public int size() {
-    return bindings.size();
+    return bindings.size() + serviceAccounts.size();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/PrincipalManager.java
+++ b/src/main/java/com/purbon/kafka/topology/PrincipalManager.java
@@ -1,0 +1,88 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.actions.accounts.ClearAccounts;
+import com.purbon.kafka.topology.actions.accounts.CreateAccounts;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.model.User;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import com.purbon.kafka.topology.serviceAccounts.VoidPrincipalProvider;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PrincipalManager {
+
+  private static final Logger LOGGER = LogManager.getLogger(PrincipalManager.class);
+
+  private PrincipalProvider provider;
+
+  private TopologyBuilderConfig config;
+
+  public PrincipalManager(PrincipalProvider provider, TopologyBuilderConfig config) {
+    this.provider = provider;
+    this.config = config;
+  }
+
+  public void apply(Topology topology, ExecutionPlan plan) throws IOException {
+    if (!config.enabledExperimental()) {
+      LOGGER.debug("Not running the PrincipalsManager as this is an experimental feature.");
+      return;
+    }
+    // Do Nothing if the provider is the void one.
+    // This means the management of principals is either not possible or has not been configured
+    List<String> principals = parseListOfPrincipals(topology);
+    if (!(provider instanceof VoidPrincipalProvider)) {
+      provider.configure();
+      managePrincipals(principals, plan);
+    }
+  }
+
+  private void managePrincipals(List<String> principals, ExecutionPlan plan) {
+
+    Map<String, ServiceAccount> accounts =
+        plan.getServiceAccounts().stream()
+            .collect(Collectors.toMap(ServiceAccount::getName, serviceAccount -> serviceAccount));
+
+    // build list of principals to be created.
+    List<ServiceAccount> principalsToBeCreated =
+        principals.stream()
+            .filter(wishPrincipal -> !accounts.containsKey(wishPrincipal))
+            .map(principal -> new ServiceAccount(-1, principal, "Managed by KTB"))
+            .collect(Collectors.toList());
+
+    if (!principalsToBeCreated.isEmpty()) {
+      plan.add(new CreateAccounts(provider, principalsToBeCreated));
+    }
+
+    // build list of principals to be deleted.
+    if (config.allowDelete() || config.isAllowDeletePrincipals()) {
+      List<ServiceAccount> principalsToBeDeleted =
+          accounts.values().stream()
+              .filter(currentPrincipal -> !principals.contains(currentPrincipal.getName()))
+              .collect(Collectors.toList());
+      if (!principalsToBeDeleted.isEmpty()) {
+        plan.add(new ClearAccounts(provider, principalsToBeDeleted));
+      }
+    }
+  }
+
+  private List<String> parseListOfPrincipals(Topology topology) {
+    return topology.getProjects().stream()
+        .flatMap(
+            project -> {
+              List<User> users = new ArrayList<>();
+              users.addAll(project.getConsumers());
+              users.addAll(project.getProducers());
+              users.addAll(project.getStreams());
+              users.addAll(project.getConnectors());
+              users.addAll(project.getSchemas());
+              return users.stream();
+            })
+        .map(User::getPrincipal)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/PrincipalProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/PrincipalProvider.java
@@ -1,0 +1,16 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.List;
+
+public interface PrincipalProvider {
+
+  void configure() throws IOException;
+
+  List<ServiceAccount> listServiceAccounts() throws IOException;
+
+  ServiceAccount createServiceAccount(String principal, String description) throws IOException;
+
+  void deleteServiceAccount(String principal) throws IOException;
+}

--- a/src/main/java/com/purbon/kafka/topology/PrincipalProviderFactory.java
+++ b/src/main/java/com/purbon/kafka/topology/PrincipalProviderFactory.java
@@ -1,0 +1,23 @@
+package com.purbon.kafka.topology;
+
+import static com.purbon.kafka.topology.TopologyBuilderConfig.CCLOUD_ENV_CONFIG;
+
+import com.purbon.kafka.topology.serviceAccounts.CCloudPrincipalProvider;
+import com.purbon.kafka.topology.serviceAccounts.VoidPrincipalProvider;
+
+public class PrincipalProviderFactory {
+
+  private TopologyBuilderConfig config;
+
+  public PrincipalProviderFactory(TopologyBuilderConfig config) {
+    this.config = config;
+  }
+
+  public PrincipalProvider get() {
+    if (config.hasProperty(CCLOUD_ENV_CONFIG)) {
+      return new CCloudPrincipalProvider(config);
+    } else {
+      return new VoidPrincipalProvider();
+    }
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -65,6 +65,13 @@ public class TopologyBuilderConfig {
 
   static final String ALLOW_DELETE_TOPICS = "allow.delete.topics";
   static final String ALLOW_DELETE_BINDINGS = "allow.delete.bindings";
+  static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
+
+  public static final String CCLOUD_ENV_CONFIG = "ccloud.environment";
+
+  static final String TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG = "topology.features.experimental";
+  static final String TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG =
+      "topology.translation.principal.enabled";
 
   private final Map<String, String> cliParams;
   private Config config;
@@ -263,6 +270,22 @@ public class TopologyBuilderConfig {
     return config.getBoolean(OPTIMIZED_ACLS_CONFIG);
   }
 
+  public String getConfluentCloudEnv() {
+    return config.getString(CCLOUD_ENV_CONFIG);
+  }
+
+  public boolean enabledExperimental() {
+    return config.getBoolean(TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG);
+  }
+
+  public boolean useConfuentCloud() {
+    return config.hasPath(CCLOUD_ENV_CONFIG);
+  }
+
+  public boolean hasProperty(String property) {
+    return config.hasPath(property);
+  }
+
   public List<String> getTopologyValidations() {
     List<String> classes = config.getStringList(TOPOLOGY_VALIDATIONS_CONFIG);
     return classes.stream().map(String::trim).collect(Collectors.toList());
@@ -290,5 +313,13 @@ public class TopologyBuilderConfig {
 
   public boolean isAllowDeleteBindings() {
     return config.getBoolean(ALLOW_DELETE_BINDINGS);
+  }
+
+  public boolean isAllowDeletePrincipals() {
+    return config.getBoolean(ALLOW_DELETE_PRINCIPALS);
+  }
+
+  public boolean enabledPrincipalTranslation() {
+    return config.getBoolean(TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/actions/BaseAccountsAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/BaseAccountsAction.java
@@ -1,0 +1,48 @@
+package com.purbon.kafka.topology.actions;
+
+import com.purbon.kafka.topology.PrincipalProvider;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class BaseAccountsAction extends BaseAction {
+
+  protected PrincipalProvider provider;
+  protected Collection<ServiceAccount> accounts;
+
+  public BaseAccountsAction(PrincipalProvider provider, Collection<ServiceAccount> accounts) {
+    this.provider = provider;
+    this.accounts = accounts;
+  }
+
+  public Collection<ServiceAccount> getPrincipals() {
+    return accounts;
+  }
+
+  @Override
+  protected Map<String, Object> props() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("Operation", getClass().getName());
+    map.put("Principals", accounts);
+    return map;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BaseAccountsAction)) {
+      return false;
+    }
+    BaseAccountsAction that = (BaseAccountsAction) o;
+    return Objects.equals(provider, that.provider) && Objects.equals(accounts, that.accounts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(provider, accounts);
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/actions/accounts/ClearAccounts.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/accounts/ClearAccounts.java
@@ -1,0 +1,26 @@
+package com.purbon.kafka.topology.actions.accounts;
+
+import com.purbon.kafka.topology.PrincipalProvider;
+import com.purbon.kafka.topology.actions.BaseAccountsAction;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ClearAccounts extends BaseAccountsAction {
+
+  private static final Logger LOGGER = LogManager.getLogger(ClearAccounts.class);
+
+  public ClearAccounts(PrincipalProvider provider, Collection<ServiceAccount> accounts) {
+    super(provider, accounts);
+  }
+
+  @Override
+  public void run() throws IOException {
+    LOGGER.debug("ClearPrincipals " + accounts);
+    for (ServiceAccount account : accounts) {
+      provider.deleteServiceAccount(account.getName());
+    }
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/actions/accounts/CreateAccounts.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/accounts/CreateAccounts.java
@@ -1,0 +1,32 @@
+package com.purbon.kafka.topology.actions.accounts;
+
+import com.purbon.kafka.topology.PrincipalProvider;
+import com.purbon.kafka.topology.actions.BaseAccountsAction;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CreateAccounts extends BaseAccountsAction {
+
+  private static final Logger LOGGER = LogManager.getLogger(CreateAccounts.class);
+
+  public CreateAccounts(PrincipalProvider provider, Collection<ServiceAccount> accounts) {
+    super(provider, accounts);
+  }
+
+  @Override
+  public void run() throws IOException {
+    LOGGER.debug("CreatePrincipals " + accounts);
+    Set<ServiceAccount> mappedAccounts = new HashSet<>();
+    for (ServiceAccount account : accounts) {
+      ServiceAccount sa =
+          provider.createServiceAccount(account.getName(), account.getDescription());
+      mappedAccounts.add(sa);
+    }
+    accounts = mappedAccounts;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
+++ b/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
@@ -1,0 +1,131 @@
+package com.purbon.kafka.topology.api.ccloud;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.purbon.kafka.topology.model.cluster.Cluster;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CCloudCLI {
+
+  private static final Logger LOGGER = LogManager.getLogger(CCloudCLI.class);
+
+  private ObjectMapper mapper;
+
+  public CCloudCLI() {
+    mapper = new ObjectMapper();
+  }
+
+  public List<Cluster> clusters() throws IOException {
+    List<String> cmd = Arrays.asList("ccloud", "kafka", "cluster", "list", "--output", "json");
+    String stdout = "";
+    try {
+      stdout = run(cmd);
+      Cluster[] items = mapper.readValue(stdout, Cluster[].class);
+      return Arrays.asList(items);
+    } catch (IOException | InterruptedException e) {
+      handleError(stdout, e);
+    }
+    return null;
+  }
+
+  public Map<String, ServiceAccount> serviceAccounts() throws IOException {
+    List<String> cmd = Arrays.asList("ccloud", "service-account", "list", "--output", "json");
+    String stdout = "";
+    try {
+      stdout = run(cmd);
+      ServiceAccount[] items = mapper.readValue(stdout, ServiceAccount[].class);
+      return Arrays.asList(items).stream()
+          .collect(Collectors.toMap(ServiceAccount::getName, i -> i));
+    } catch (IOException | InterruptedException e) {
+      handleError(stdout, e);
+      return null;
+    }
+  }
+
+  public void setEnvironment(String environment) throws IOException {
+    List<String> cmd = Arrays.asList("ccloud", "environment", "use", environment);
+    String stdout = "";
+    try {
+      stdout = run(cmd);
+    } catch (IOException | InterruptedException e) {
+      handleError(stdout, e);
+    }
+  }
+
+  public ServiceAccount newServiceAccount(String name, String description) throws IOException {
+    List<String> cmd =
+        Arrays.asList(
+            "ccloud",
+            "service-account",
+            "create",
+            name,
+            "--description",
+            description,
+            "--output",
+            "json");
+    String stdout = "";
+    ServiceAccount sa = null;
+    try {
+      stdout = run(cmd);
+      sa = mapper.readValue(stdout, ServiceAccount.class);
+    } catch (IOException | InterruptedException e) {
+      handleError(stdout, e);
+    }
+    return sa;
+  }
+
+  public void deleteServiceAccount(int id) throws IOException {
+    List<String> cmd = Arrays.asList("ccloud", "service-account", "delete", String.valueOf(id));
+    String stdout = "";
+    try {
+      stdout = run(cmd);
+    } catch (IOException | InterruptedException e) {
+      handleError(stdout, e);
+    }
+  }
+
+  private void handleError(String stdout, Exception e) throws IOException {
+    String errorMsg = String.format("Something happen with ccloud. \n %s", stdout);
+    LOGGER.error(errorMsg, e);
+    throw new IOException(e);
+  }
+
+  private String run(List<String> cmd) throws IOException, InterruptedException {
+
+    ProcessBuilder builder = new ProcessBuilder();
+    builder.command(cmd);
+    builder.redirectErrorStream(true);
+
+    Process pr = builder.start();
+    String stdout = readStdOut(pr);
+    pr.waitFor();
+
+    LOGGER.debug("Exit code: " + pr.exitValue());
+    return stdout;
+  }
+
+  private String readStdOut(Process pr) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(pr.getInputStream()));
+    StringBuilder sb = new StringBuilder();
+    String line = null;
+    while ((line = br.readLine()) != null) {
+      sb.append(line);
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    CCloudCLI cli = new CCloudCLI();
+    cli.setEnvironment("env-j9wgp");
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -1,9 +1,9 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Set;
 
 public interface Backend {
@@ -12,13 +12,15 @@ public interface Backend {
 
   void createOrOpen(BackendController.Mode mode);
 
-  Set<TopologyAclBinding> load() throws IOException;
+  Set<ServiceAccount> loadServiceAccounts() throws IOException;
 
-  Set<TopologyAclBinding> load(URI uri) throws IOException;
+  Set<TopologyAclBinding> loadBindings() throws IOException;
 
   void saveType(String type);
 
   void saveBindings(Set<TopologyAclBinding> bindings);
+
+  void saveAccounts(Set<ServiceAccount> accounts);
 
   void close();
 }

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -1,11 +1,18 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController.Mode;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import com.purbon.kafka.topology.utils.JSON;
 import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -49,7 +56,7 @@ public class FileBackend implements Backend {
     }
   }
 
-  public Set<TopologyAclBinding> load() throws IOException {
+  public Set<TopologyAclBinding> loadBindings() throws IOException {
     if (writer == null) {
       throw new IOException("state file does not exist");
     }
@@ -65,16 +72,41 @@ public class FileBackend implements Backend {
     String line = null;
     while ((line = in.readLine()) != null) {
       TopologyAclBinding binding = null;
+      if (line.equalsIgnoreCase("ServiceAccounts")) {
+        // process service accounts, should break from here.
+        break;
+      }
       if (type.equalsIgnoreCase("acls")) {
         binding = buildAclBinding(line);
-      } else if (type.equalsIgnoreCase("rbac")) {
-        binding = buildRBACBinding(line);
       } else {
         throw new IOException("Binding type ( " + type + " )not supported.");
       }
       bindings.add(binding);
     }
     return bindings;
+  }
+
+  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
+    if (writer == null) {
+      throw new IOException("state file does not exist");
+    }
+    Path filePath = Paths.get(STATE_FILE_NAME);
+    Set<ServiceAccount> accounts = new HashSet<>();
+    BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()));
+    String line = null;
+    while ((line = in.readLine()) != null) {
+      if (line.equalsIgnoreCase("ServiceAccounts")) {
+        // process service accounts, should break from here.
+        break;
+      }
+    }
+    if (line != null && line.equalsIgnoreCase("ServiceAccounts")) {
+      while ((line = in.readLine()) != null) {
+        ServiceAccount account = (ServiceAccount) JSON.toObject(line, ServiceAccount.class);
+        accounts.add(account);
+      }
+    }
+    return accounts;
   }
 
   private TopologyAclBinding buildRBACBinding(String line) {
@@ -121,6 +153,19 @@ public class FileBackend implements Backend {
                 LOGGER.error(e);
               }
             });
+  }
+
+  @Override
+  public void saveAccounts(Set<ServiceAccount> accounts) {
+    accounts.forEach(
+        account -> {
+          try {
+            writer.writeBytes(JSON.asString(account));
+            writer.writeBytes("\n");
+          } catch (IOException e) {
+            LOGGER.error(e);
+          }
+        });
   }
 
   @Override

--- a/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
@@ -1,9 +1,9 @@
 package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.BackendController.Mode;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
-import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -48,13 +48,12 @@ public class RedisBackend implements Backend {
   }
 
   @Override
-  public Set<TopologyAclBinding> load() throws IOException {
-    return load(null);
+  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
+    return new HashSet<>();
   }
 
   @Override
-  public Set<TopologyAclBinding> load(URI uri) throws IOException {
-
+  public Set<TopologyAclBinding> loadBindings() throws IOException {
     if (!jedis.isConnected()) {
       createOrOpen();
     }
@@ -85,6 +84,9 @@ public class RedisBackend implements Backend {
 
     jedis.sadd(KAFKA_TOPOLOGY_BUILDER_BINDINGS, members);
   }
+
+  @Override
+  public void saveAccounts(Set<ServiceAccount> accounts) {}
 
   @Override
   public void close() {

--- a/src/main/java/com/purbon/kafka/topology/model/cluster/Cluster.java
+++ b/src/main/java/com/purbon/kafka/topology/model/cluster/Cluster.java
@@ -1,0 +1,61 @@
+package com.purbon.kafka.topology.model.cluster;
+
+public class Cluster {
+
+  private String availability;
+  private String id;
+  private String name;
+  private String provider;
+  private String region;
+  private String status;
+  private String type;
+
+  public Cluster() {
+    this("", "", "", "", "", "", "");
+  }
+
+  public Cluster(
+      String availability,
+      String id,
+      String name,
+      String provider,
+      String region,
+      String status,
+      String type) {
+    this.availability = availability;
+    this.id = id;
+    this.name = name;
+    this.provider = provider;
+    this.region = region;
+    this.status = status;
+    this.type = type;
+  }
+
+  public String getAvailability() {
+    return availability;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getType() {
+    return type;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
+++ b/src/main/java/com/purbon/kafka/topology/model/cluster/ServiceAccount.java
@@ -1,0 +1,58 @@
+package com.purbon.kafka.topology.model.cluster;
+
+import java.util.Objects;
+
+public class ServiceAccount {
+
+  private int id;
+  private String name;
+  private String description;
+
+  public ServiceAccount() {
+    this(-1, "", "");
+  }
+
+  public ServiceAccount(int id, String name, String description) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("ServiceAccount{");
+    sb.append("id=").append(id);
+    sb.append(", name='").append(name).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ServiceAccount)) {
+      return false;
+    }
+    ServiceAccount that = (ServiceAccount) o;
+    return getName().equals(that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getName(), getDescription());
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/acls/AclsBindingsBuilder.java
@@ -5,11 +5,14 @@ import static java.util.Arrays.asList;
 import com.purbon.kafka.topology.BindingsBuilderProvider;
 import com.purbon.kafka.topology.TopologyBuilderConfig;
 import com.purbon.kafka.topology.api.adminclient.AclBuilder;
+import com.purbon.kafka.topology.api.ccloud.CCloudCLI;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.Producer;
 import com.purbon.kafka.topology.model.users.platform.SchemaRegistryInstance;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import com.purbon.kafka.topology.utils.CCloudUtils;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,19 +26,29 @@ import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AclsBindingsBuilder implements BindingsBuilderProvider {
 
+  private static final Logger LOGGER = LogManager.getLogger(AclsBindingsBuilder.class);
+
   private final TopologyBuilderConfig config;
+  private final CCloudUtils cCloudUtils;
 
   public AclsBindingsBuilder(TopologyBuilderConfig config) {
+    this(config, new CCloudUtils(new CCloudCLI(), config));
+  }
+
+  public AclsBindingsBuilder(TopologyBuilderConfig config, CCloudUtils cCloudUtils) {
     this.config = config;
+    this.cCloudUtils = cCloudUtils;
   }
 
   @Override
   public List<TopologyAclBinding> buildBindingsForConnect(Connector connector, String topicPrefix) {
 
-    String principal = connector.getPrincipal();
+    String principal = translate(connector.getPrincipal());
     List<String> readTopics = connector.getTopics().get("read");
     List<String> writeTopics = connector.getTopics().get("write");
 
@@ -82,8 +95,8 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
 
   @Override
   public List<TopologyAclBinding> buildBindingsForStreamsApp(
-      String principal, String prefix, List<String> readTopics, List<String> writeTopics) {
-    return toList(streamsAppStream(principal, prefix, readTopics, writeTopics));
+      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics) {
+    return toList(streamsAppStream(translate(principal), topicPrefix, readTopics, writeTopics));
   }
 
   @Override
@@ -108,7 +121,7 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
 
   @Override
   public List<TopologyAclBinding> buildBindingsForControlCenter(String principal, String appId) {
-    return toList(controlCenterStream(principal, appId));
+    return toList(controlCenterStream(translate(principal), appId));
   }
 
   private List<TopologyAclBinding> toList(Stream<AclBinding> bindingStream) {
@@ -119,11 +132,11 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
     PatternType patternType = prefixed ? PatternType.PREFIXED : PatternType.LITERAL;
 
     List<AclBinding> bindings = new ArrayList<>();
-
+    String principal = translate(producer.getPrincipal());
     bindings.addAll(
         Arrays.asList(
-            buildTopicLevelAcl(producer.getPrincipal(), topic, patternType, AclOperation.DESCRIBE),
-            buildTopicLevelAcl(producer.getPrincipal(), topic, patternType, AclOperation.WRITE)));
+            buildTopicLevelAcl(principal, topic, patternType, AclOperation.DESCRIBE),
+            buildTopicLevelAcl(principal, topic, patternType, AclOperation.WRITE)));
 
     producer
         .getTransactionId()
@@ -157,11 +170,11 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
 
   private Stream<AclBinding> consumerAclsStream(Consumer consumer, String topic, boolean prefixed) {
     PatternType patternType = prefixed ? PatternType.PREFIXED : PatternType.LITERAL;
+    String principal = translate(consumer.getPrincipal());
     return Stream.of(
-        buildTopicLevelAcl(consumer.getPrincipal(), topic, patternType, AclOperation.DESCRIBE),
-        buildTopicLevelAcl(consumer.getPrincipal(), topic, patternType, AclOperation.READ),
-        buildGroupLevelAcl(
-            consumer.getPrincipal(), consumer.groupString(), patternType, AclOperation.READ));
+        buildTopicLevelAcl(principal, topic, patternType, AclOperation.DESCRIBE),
+        buildTopicLevelAcl(principal, topic, patternType, AclOperation.READ),
+        buildGroupLevelAcl(principal, consumer.groupString(), patternType, AclOperation.READ));
   }
 
   private Stream<AclBinding> streamsAppStream(
@@ -186,15 +199,13 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
   }
 
   private Stream<AclBinding> schemaRegistryAclsStream(SchemaRegistryInstance schemaRegistry) {
+    String principal = translate(schemaRegistry.getPrincipal());
     List<AclBinding> bindings =
         Stream.of(AclOperation.DESCRIBE_CONFIGS, AclOperation.WRITE, AclOperation.READ)
             .map(
                 aclOperation ->
                     buildTopicLevelAcl(
-                        schemaRegistry.getPrincipal(),
-                        schemaRegistry.topicString(),
-                        PatternType.LITERAL,
-                        aclOperation))
+                        principal, schemaRegistry.topicString(), PatternType.LITERAL, aclOperation))
             .collect(Collectors.toList());
     return bindings.stream();
   }
@@ -239,6 +250,22 @@ public class AclsBindingsBuilder implements BindingsBuilderProvider {
             principal, "*", AclOperation.DESCRIBE_CONFIGS, AclPermissionType.ALLOW);
     bindings.add(new AclBinding(resourcePattern, entry));
     return bindings.stream();
+  }
+
+  private String translate(String namedPrincipal) {
+    if (config.useConfuentCloud()
+        && config.enabledExperimental()
+        && config.enabledPrincipalTranslation()) {
+      try {
+        cCloudUtils.warmup();
+      } catch (IOException e) {
+        LOGGER.error("Something happen during a ccloud cli warmup", e);
+      }
+      int id = cCloudUtils.translate(namedPrincipal); // Check with the part after User:
+      return "User:" + id;
+    } else {
+      return namedPrincipal;
+    }
   }
 
   private AclBinding buildTopicLevelAcl(

--- a/src/main/java/com/purbon/kafka/topology/serviceAccounts/CCloudPrincipalProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/serviceAccounts/CCloudPrincipalProvider.java
@@ -1,0 +1,44 @@
+package com.purbon.kafka.topology.serviceAccounts;
+
+import com.purbon.kafka.topology.PrincipalProvider;
+import com.purbon.kafka.topology.TopologyBuilderConfig;
+import com.purbon.kafka.topology.api.ccloud.CCloudCLI;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CCloudPrincipalProvider implements PrincipalProvider {
+
+  private CCloudCLI cCloudCLI;
+  private String env;
+
+  public CCloudPrincipalProvider(TopologyBuilderConfig config) {
+    this.cCloudCLI = new CCloudCLI();
+    this.env = config.getConfluentCloudEnv();
+  }
+
+  @Override
+  public void configure() throws IOException {
+    cCloudCLI.setEnvironment(env);
+  }
+
+  @Override
+  public List<ServiceAccount> listServiceAccounts() throws IOException {
+    return new ArrayList<>(cCloudCLI.serviceAccounts().values());
+  }
+
+  @Override
+  public ServiceAccount createServiceAccount(String principal, String description)
+      throws IOException {
+    return cCloudCLI.newServiceAccount(principal, description);
+  }
+
+  @Override
+  public void deleteServiceAccount(String principal) throws IOException {
+    Map<String, ServiceAccount> accounts = cCloudCLI.serviceAccounts();
+    ServiceAccount sa = accounts.get(principal);
+    cCloudCLI.deleteServiceAccount(sa.getId());
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/serviceAccounts/VoidPrincipalProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/serviceAccounts/VoidPrincipalProvider.java
@@ -1,0 +1,30 @@
+package com.purbon.kafka.topology.serviceAccounts;
+
+import com.purbon.kafka.topology.PrincipalProvider;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.List;
+
+public class VoidPrincipalProvider implements PrincipalProvider {
+
+  @Override
+  public void configure() throws IOException {
+    throw new IOException("Not implemented!!");
+  }
+
+  @Override
+  public List<ServiceAccount> listServiceAccounts() throws IOException {
+    throw new IOException("Not implemented!!");
+  }
+
+  @Override
+  public ServiceAccount createServiceAccount(String principal, String description)
+      throws IOException {
+    throw new IOException("Not implemented!!");
+  }
+
+  @Override
+  public void deleteServiceAccount(String principal) throws IOException {
+    throw new IOException("Not implemented!!");
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/utils/CCloudUtils.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/CCloudUtils.java
@@ -1,0 +1,42 @@
+package com.purbon.kafka.topology.utils;
+
+import com.purbon.kafka.topology.TopologyBuilderConfig;
+import com.purbon.kafka.topology.api.ccloud.CCloudCLI;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CCloudUtils {
+
+  private final CCloudCLI cli;
+  private String env;
+  private Map<String, ServiceAccount> serviceAccounts;
+  private boolean warmed;
+
+  public CCloudUtils(CCloudCLI cli, TopologyBuilderConfig config) {
+    this.cli = cli;
+    this.env = config.useConfuentCloud() ? config.getConfluentCloudEnv() : "";
+    this.serviceAccounts = new HashMap<>();
+    this.warmed = false;
+  }
+
+  public void warmup() throws IOException {
+    if (warmed) {
+      return;
+    }
+
+    if (serviceAccounts.isEmpty()) {
+      if (env.isEmpty()) {
+        throw new IOException("Environment can't be empty");
+      }
+      cli.setEnvironment(env);
+      this.serviceAccounts = cli.serviceAccounts();
+      this.warmed = true;
+    }
+  }
+
+  public int translate(String name) {
+    return serviceAccounts.containsKey(name) ? serviceAccounts.get(name).getId() : -1;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/utils/JSON.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/JSON.java
@@ -24,4 +24,13 @@ public class JSON {
   public static List<String> toArray(String jsonString) throws JsonProcessingException {
     return mapper.readValue(jsonString, List.class);
   }
+
+  public static String asString(Object account) throws JsonProcessingException {
+    return mapper.writeValueAsString(account);
+  }
+
+  public static Object toObject(String jsonString, Class objectClazz)
+      throws JsonProcessingException {
+    return mapper.readValue(jsonString, objectClazz);
+  }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,7 +5,13 @@ topology {
   file {
     type = "YAML"
   }
+  features {
+    experimental = false
+  }
   validations = []
+  translation {
+     principal.enabled = false
+   }
   builder {
     access.control.class = "com.purbon.kafka.topology.roles.SimpleAclsProvider"
     mds {

--- a/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/PrincipalManagerTest.java
@@ -1,0 +1,162 @@
+package com.purbon.kafka.topology;
+
+import static com.purbon.kafka.topology.BuilderCLI.ALLOW_DELETE_OPTION;
+import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.purbon.kafka.topology.actions.Action;
+import com.purbon.kafka.topology.actions.accounts.ClearAccounts;
+import com.purbon.kafka.topology.actions.accounts.CreateAccounts;
+import com.purbon.kafka.topology.model.Impl.ProjectImpl;
+import com.purbon.kafka.topology.model.Impl.TopologyImpl;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import com.purbon.kafka.topology.model.users.Consumer;
+import com.purbon.kafka.topology.model.users.Producer;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class PrincipalManagerTest {
+
+  private Map<String, String> cliOps;
+  private Properties props;
+
+  @Mock PrincipalProvider provider;
+
+  ExecutionPlan plan;
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  PrincipalManager principalManager;
+  TopologyBuilderConfig config;
+
+  BackendController backendController;
+
+  @Mock PrintStream mockPrintStream;
+
+  @Mock ExecutionPlan mockPlan;
+
+  @Before
+  public void before() throws IOException {
+
+    Files.deleteIfExists(Paths.get(".cluster-state"));
+    backendController = new BackendController();
+
+    cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+    cliOps.put(ALLOW_DELETE_OPTION, "true");
+    props = new Properties();
+
+    props.put(TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG, "true");
+
+    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    config = new TopologyBuilderConfig(cliOps, props);
+    principalManager = new PrincipalManager(provider, config);
+  }
+
+  @Test
+  public void testFreshGeneration() throws IOException {
+
+    Topology topology = new TopologyImpl();
+    topology.setContext("context");
+    Project project = new ProjectImpl("foo");
+    project.setConsumers(Collections.singletonList(new Consumer("consumer")));
+    project.setProducers(Collections.singletonList(new Producer("producer")));
+    topology.addProject(project);
+
+    doNothing().when(provider).configure();
+
+    principalManager.apply(topology, plan);
+
+    Collection<ServiceAccount> accounts =
+        Arrays.asList(
+            new ServiceAccount(-1, "consumer", "Managed by KTB"),
+            new ServiceAccount(-1, "producer", "Managed by KTB"));
+
+    assertThat(plan.getActions()).hasSize(1);
+    assertThat(plan.getActions()).containsAnyOf(new CreateAccounts(provider, accounts));
+  }
+
+  @Test
+  public void testDeleteAccountsRequired() throws IOException {
+
+    Topology topology = new TopologyImpl();
+    topology.setContext("context");
+    Project project = new ProjectImpl("foo");
+    project.setConsumers(Collections.singletonList(new Consumer("consumer")));
+    project.setProducers(Collections.singletonList(new Producer("producer")));
+    topology.addProject(project);
+
+    doNothing().when(provider).configure();
+
+    doReturn(new ServiceAccount(123, "consumer", "Managed by KTB"))
+        .when(provider)
+        .createServiceAccount(eq("consumer"), eq("Managed by KTB"));
+
+    doReturn(new ServiceAccount(124, "producer", "Managed by KTB"))
+        .when(provider)
+        .createServiceAccount(eq("producer"), eq("Managed by KTB"));
+
+    principalManager.apply(topology, plan);
+    plan.run();
+    assertThat(plan.getServiceAccounts()).hasSize(2);
+
+    topology = new TopologyImpl();
+    topology.setContext("context");
+    project = new ProjectImpl("foo");
+    project.setConsumers(Collections.singletonList(new Consumer("consumer")));
+    topology.addProject(project);
+
+    backendController = new BackendController();
+    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    principalManager.apply(topology, plan);
+
+    Collection<ServiceAccount> accounts =
+        Arrays.asList(new ServiceAccount(124, "producer", "Managed by KTB"));
+
+    assertThat(plan.getActions()).hasSize(1);
+    assertThat(plan.getActions()).containsAnyOf(new ClearAccounts(provider, accounts));
+
+    plan.run();
+
+    assertThat(plan.getServiceAccounts()).hasSize(1);
+    assertThat(plan.getServiceAccounts())
+        .contains(new ServiceAccount(123, "consumer", "Managed by KTB"));
+  }
+
+  @Test
+  public void testNotRunIfConfigNotExperimental() throws IOException {
+    props.put(TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG, "false");
+
+    config = new TopologyBuilderConfig(cliOps, props);
+    principalManager = new PrincipalManager(provider, config);
+
+    Topology topology = new TopologyImpl();
+
+    principalManager.apply(topology, mockPlan);
+
+    verify(mockPlan, times(0)).add(any(Action.class));
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/backend/RedisBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/RedisBackendTest.java
@@ -59,7 +59,7 @@ public class RedisBackendTest {
         .thenReturn("'TOPIC', 'topicA', '*', 'READ', 'User:Connect1', 'LITERAL'")
         .thenReturn("'TOPIC', 'topicB', '*', 'READ', 'User:Connect1', 'LITERAL'");
 
-    Set<TopologyAclBinding> bindings = stateProcessor.load();
+    Set<TopologyAclBinding> bindings = stateProcessor.loadBindings();
 
     assertEquals(2, bindings.size());
   }

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/DefaultBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/DefaultBackendIT.java
@@ -1,0 +1,75 @@
+package com.purbon.kafka.topology.integration.backend;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.purbon.kafka.topology.BackendController;
+import com.purbon.kafka.topology.model.cluster.ServiceAccount;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultBackendIT {
+
+  BackendController backend;
+
+  @Before
+  public void before() throws IOException {
+    Files.deleteIfExists(Paths.get(".cluster-state"));
+    backend = new BackendController();
+  }
+
+  @Test
+  public void saveAndRestoreBindingsAndAccountsTest() throws IOException {
+
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
+
+    ServiceAccount serviceAccount = new ServiceAccount(1, "name", "description");
+    ServiceAccount serviceAccount2 = new ServiceAccount(2, "name2", "description2");
+
+    Set<ServiceAccount> accounts = new HashSet<>(Arrays.asList(serviceAccount, serviceAccount2));
+
+    backend.add(Collections.singletonList(binding));
+    backend.addServiceAccounts(accounts);
+    backend.flushAndClose();
+
+    // reopen a new connection
+    backend = new BackendController();
+    backend.load();
+
+    assertThat(backend.getBindings()).isNotNull();
+    assertThat(backend.getBindings()).isEqualTo(Collections.singleton(binding));
+    assertThat(backend.getServiceAccounts()).isNotNull();
+    assertThat(backend.getServiceAccounts()).isEqualTo(accounts);
+  }
+
+  @Test
+  public void saveAndRestoreBindingsWithNoAccounts() throws IOException {
+
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
+
+    backend.add(Collections.singletonList(binding));
+    backend.flushAndClose();
+
+    // reopen a new connection
+    backend = new BackendController();
+    backend.load();
+
+    assertThat(backend.getBindings()).isNotNull();
+    assertThat(backend.getBindings()).isEqualTo(Collections.singleton(binding));
+    assertThat(backend.getServiceAccounts()).isNotNull();
+    assertEquals(0, backend.getServiceAccounts().size());
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -33,7 +33,7 @@ public class RedisBackendIT {
             ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");
     rsp.saveBindings(new HashSet<>(Arrays.asList(binding)));
 
-    Set<TopologyAclBinding> bindings = rsp.load();
+    Set<TopologyAclBinding> bindings = rsp.loadBindings();
 
     Assert.assertEquals(1, bindings.size());
     Assert.assertEquals(binding.getPrincipal(), bindings.iterator().next().getPrincipal());


### PR DESCRIPTION
This pull request add support for calling the _ccloud_ CLI when interacting with *Confluent Cloud*, like this users can manage more details directly and automatically with ccloud. 

As the first usage of ccloud, it is used here to manage the creation of service accounts. 

Pending:

- [x] Manual integration test with Confluent Cloud.
- [x] Add a specific flag to enable/disable the translation between the service account name and the service account id.


closes #10  