### PR TITLE
Improve AccessControlManagerTest

### DIFF
--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.OPTIMIZED_ACLS_CONFIG;
 import static java.util.Arrays.asList;
@@ -76,7 +77,7 @@ public class AccessControlManagerTest {
     Topic topicA = new TopicImpl("topicA");
     TestTopologyBuilder builder =
         TestTopologyBuilder.createProject().addTopic(topicA).addConsumer("User:app1");
-    List<Consumer> users = new ArrayList<>(builder.getConsumers());
+    List<Consumer> users = newArrayList(builder.getConsumers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
@@ -99,7 +100,7 @@ public class AccessControlManagerTest {
 
     TestTopologyBuilder builder =
         TestTopologyBuilder.createProject().addTopic("topicA").addConsumer("User:app1");
-    List<Consumer> users = new ArrayList<>(builder.getConsumers());
+    List<Consumer> users = newArrayList(builder.getConsumers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
@@ -152,7 +153,7 @@ public class AccessControlManagerTest {
     Topic topicA = new TopicImpl("topicA");
     TestTopologyBuilder builder =
         TestTopologyBuilder.createProject().addTopic(topicA).addProducer("User:app1");
-    List<Producer> producers = new ArrayList<>(builder.getProducers());
+    List<Producer> producers = newArrayList(builder.getProducers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
@@ -175,7 +176,7 @@ public class AccessControlManagerTest {
 
     TestTopologyBuilder builder =
         TestTopologyBuilder.createProject().addTopic("topicA").addProducer("User:app1");
-    List<Producer> producers = new ArrayList<>(builder.getProducers());
+    List<Producer> producers = newArrayList(builder.getProducers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
@@ -407,7 +408,7 @@ public class AccessControlManagerTest {
         TestTopologyBuilder.createProject("foo", "project")
             .addTopic(topicA)
             .addConsumer("User:app1");
-    List<Consumer> users = new ArrayList<>(builder.getConsumers());
+    List<Consumer> users = newArrayList(builder.getConsumers());
 
     doReturn(singletonList(new TopologyAclBinding()))
         .when(aclsBuilder)
@@ -424,33 +425,33 @@ public class AccessControlManagerTest {
   public void testAclDeleteWithDeleteAllEnabled() throws IOException {
     doReturn(true).when(config).allowDelete();
 
-    verifyAclsDelete();
+    testAclsDelete();
   }
 
   @Test
-  public void testAclDeleteWithDeleteDisabled() throws IOException {
+  public void testAclDeleteWithDeleteAllDisabled() throws IOException {
     doReturn(false).when(config).allowDelete();
 
-    verifyNoAclsDeleted();
+    testNoAclsDeleted();
   }
 
   @Test
-  public void testAclDeleteWithDetailedOptionsDisabled() throws IOException {
-    doReturn(false).when(config).isAllowDeleteBindings();
-    doReturn(false).when(config).isAllowDeleteTopics();
-
-    verifyNoAclsDeleted();
-  }
-
-  @Test
-  public void testBindingsDeleteWithSpecificConfigEnabled() throws IOException {
+  public void testAclDeleteWithDetailedOptionEnabled() throws IOException {
     doReturn(true).when(config).isAllowDeleteBindings();
     doReturn(false).when(config).isAllowDeleteTopics();
 
-    verifyAclsDelete();
+    testAclsDelete();
   }
 
-  private void verifyNoAclsDeleted() throws IOException {
+  @Test
+  public void testAclDeleteWithDetailedOptionDisabled() throws IOException {
+    doReturn(false).when(config).isAllowDeleteBindings();
+    doReturn(false).when(config).isAllowDeleteTopics();
+
+    testNoAclsDeleted();
+  }
+
+  private void testNoAclsDeleted() throws IOException {
     BackendController backendController = initializeFileBackendController();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
     accessControlManager =
@@ -477,7 +478,7 @@ public class AccessControlManagerTest {
     verify(aclsProvider, times(0)).clearBindings(any());
   }
 
-  private void verifyAclsDelete() throws IOException {
+  private void testAclsDelete() throws IOException {
     BackendController backendController = initializeFileBackendController();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
     accessControlManager =
@@ -511,7 +512,7 @@ public class AccessControlManagerTest {
 
   private List<TopologyAclBinding> returnAclsForConsumers(List<Consumer> consumers, String topic) {
 
-    List<AclBinding> acls = new ArrayList<>();
+    List<AclBinding> acls = newArrayList();
 
     for (Consumer consumer : consumers) {
       acls.add(

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -1,10 +1,6 @@
 package com.purbon.kafka.topology;
 
-import static com.purbon.kafka.topology.BuilderCLI.ALLOW_DELETE_OPTION;
 import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
-import static com.purbon.kafka.topology.TopologyBuilderConfig.ALLOW_DELETE_BINDINGS;
-import static com.purbon.kafka.topology.TopologyBuilderConfig.ALLOW_DELETE_TOPICS;
-import static com.purbon.kafka.topology.TopologyBuilderConfig.KAFKA_INTERNAL_TOPIC_PREFIXES;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.OPTIMIZED_ACLS_CONFIG;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -14,7 +10,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.refEq;
 import static org.mockito.Mockito.*;
 
 import com.purbon.kafka.topology.actions.Action;
@@ -47,6 +42,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -58,6 +54,7 @@ public class AccessControlManagerTest {
   @Mock BackendController backendController;
 
   @Mock PrintStream mockPrintStream;
+  @Mock TopologyBuilderConfig config;
 
   ExecutionPlan plan;
 
@@ -76,24 +73,15 @@ public class AccessControlManagerTest {
 
   @Test
   public void newConsumerACLsCreation() {
-
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-    Project project = new ProjectImpl();
-    project.setConsumers(consumers);
-
     Topic topicA = new TopicImpl("topicA");
-    project.addTopic(topicA);
-
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
-
-    List<Consumer> users = asList(new Consumer("User:app1"));
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject().addTopic(topicA).addConsumer("User:app1");
+    List<Consumer> users = new ArrayList<>(builder.getConsumers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
         .buildBindingsForConsumers(users, topicA.toString(), false);
-    accessControlManager.apply(topology, plan);
+    accessControlManager.apply(builder.buildTopology(), plan);
     verify(aclsBuilder, times(1))
         .buildBindingsForConsumers(eq(users), eq(topicA.toString()), eq(false));
   }
@@ -109,25 +97,16 @@ public class AccessControlManagerTest {
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
     accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder, config);
 
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-    Project project = new ProjectImpl();
-    project.setConsumers(consumers);
-
-    Topic topicA = new TopicImpl("topicA");
-    project.addTopic(topicA);
-
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
-
-    List<Consumer> users = asList(new Consumer("User:app1"));
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject().addTopic("topicA").addConsumer("User:app1");
+    List<Consumer> users = new ArrayList<>(builder.getConsumers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
-        .buildBindingsForConsumers(users, project.namePrefix(), true);
-    accessControlManager.apply(topology, plan);
+        .buildBindingsForConsumers(users, builder.getProject().namePrefix(), true);
+    accessControlManager.apply(builder.buildTopology(), plan);
     verify(aclsBuilder, times(1))
-        .buildBindingsForConsumers(eq(users), eq(project.namePrefix()), eq(true));
+        .buildBindingsForConsumers(eq(users), eq(builder.getProject().namePrefix()), eq(true));
   }
 
   @Test
@@ -170,23 +149,16 @@ public class AccessControlManagerTest {
 
   @Test
   public void newProducerACLsCreation() {
-
-    List<Producer> producers = new ArrayList<>();
-    producers.add(new Producer("User:app1"));
-    Project project = new ProjectImpl();
-    project.setProducers(producers);
-
     Topic topicA = new TopicImpl("topicA");
-    project.addTopic(topicA);
-
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject().addTopic(topicA).addProducer("User:app1");
+    List<Producer> producers = new ArrayList<>(builder.getProducers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
         .buildBindingsForProducers(producers, topicA.toString(), false);
 
-    accessControlManager.apply(topology, plan);
+    accessControlManager.apply(builder.buildTopology(), plan);
     verify(aclsBuilder, times(1))
         .buildBindingsForProducers(eq(producers), eq(topicA.toString()), eq(false));
   }
@@ -201,23 +173,16 @@ public class AccessControlManagerTest {
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
     accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder, config);
 
-    List<Producer> producers = new ArrayList<>();
-    producers.add(new Producer("User:app1"));
-    Project project = new ProjectImpl();
-    project.setProducers(producers);
-
-    Topic topicA = new TopicImpl("topicA");
-    project.addTopic(topicA);
-
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject().addTopic("topicA").addProducer("User:app1");
+    List<Producer> producers = new ArrayList<>(builder.getProducers());
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsBuilder)
-        .buildBindingsForProducers(producers, project.namePrefix(), true);
-    accessControlManager.apply(topology, plan);
+        .buildBindingsForProducers(producers, builder.getProject().namePrefix(), true);
+    accessControlManager.apply(builder.buildTopology(), plan);
     verify(aclsBuilder, times(1))
-        .buildBindingsForProducers(eq(producers), eq(project.namePrefix()), eq(true));
+        .buildBindingsForProducers(eq(producers), eq(builder.getProject().namePrefix()), eq(true));
   }
 
   @Test
@@ -417,7 +382,7 @@ public class AccessControlManagerTest {
     topics.put(Connector.READ_TOPICS, asList("topicA", "topicB"));
     connector1.setTopics(topics);
 
-    project.setConnectors(asList(connector1));
+    project.setConnectors(singletonList(connector1));
 
     Topology topology = new TopologyImpl();
     topology.addProject(project);
@@ -433,28 +398,22 @@ public class AccessControlManagerTest {
 
   @Test
   public void testDryRunMode() throws IOException {
-
     plan = ExecutionPlan.init(backendController, mockPrintStream);
-    Topology topology = new TopologyImpl();
-    topology.setContext("foo");
-
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-
-    Project project = new ProjectImpl("project");
-    project.setConsumers(consumers);
-    topology.addProject(project);
+    accessControlManager =
+        new AccessControlManager(aclsProvider, new AclsBindingsBuilder(config), config);
 
     Topic topicA = new TopicImpl("topicA");
-    project.addTopic(topicA);
-
-    List<Consumer> users = asList(new Consumer("User:app1"));
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject("foo", "project")
+            .addTopic(topicA)
+            .addConsumer("User:app1");
+    List<Consumer> users = new ArrayList<>(builder.getConsumers());
 
     doReturn(singletonList(new TopologyAclBinding()))
         .when(aclsBuilder)
         .buildBindingsForConsumers(users, topicA.toString(), false);
 
-    accessControlManager.apply(topology, plan);
+    accessControlManager.apply(builder.buildTopology(), plan);
 
     plan.run(true);
 
@@ -462,191 +421,92 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void testAclDeleteLogic() throws IOException {
+  public void testAclDeleteWithDeleteAllEnabled() throws IOException {
+    doReturn(true).when(config).allowDelete();
 
-    BackendController backendController = new BackendController();
-    backendController.load();
-    backendController.reset();
-
-    Properties props = new Properties();
-    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, Arrays.asList("foo.", "_"));
-
-    HashMap<String, String> cliOps = new HashMap<>();
-    cliOps.put(BROKERS_OPTION, "");
-    cliOps.put(ALLOW_DELETE_OPTION, "true");
-
-    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
-
-    plan = ExecutionPlan.init(backendController, mockPrintStream);
-    accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder, config);
-
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-    consumers.add(new Consumer("User:app2"));
-
-    Topic topicA = new TopicImpl("topicA");
-
-    Topology topology = buildTopology(consumers, asList(topicA));
-
-    List<TopologyAclBinding> bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
-
-    accessControlManager.apply(topology, plan);
-    plan.run();
-
-    verify(aclsBuilder, times(1))
-        .buildBindingsForConsumers(refEq(consumers), eq(topicA.toString()), eq(false));
-
-    consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-
-    bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
-
-    Topology newTopology = buildTopology(consumers, asList(topicA));
-
-    accessControlManager.apply(newTopology, plan);
-    plan.run();
-
-    List<TopologyAclBinding> bindingsToDelete =
-        returnAclsForConsumers(asList(new Consumer("User:app2")), topicA.getName());
-
-    verify(aclsProvider, times(1)).clearBindings(new HashSet<>(bindingsToDelete));
+    verifyAclsDelete();
   }
 
   @Test
-  public void testBindingsDeleteWithAllOptionsDisabled() throws IOException {
+  public void testAclDeleteWithDeleteDisabled() throws IOException {
+    doReturn(false).when(config).allowDelete();
 
-    BackendController backendController = new BackendController();
-    backendController.load();
-    backendController.reset();
-    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    verifyNoAclsDeleted();
+  }
 
-    Properties props = new Properties();
-    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, Arrays.asList("foo.", "_"));
-    props.put(ALLOW_DELETE_TOPICS, "false");
+  @Test
+  public void testAclDeleteWithDetailedOptionsDisabled() throws IOException {
+    doReturn(false).when(config).isAllowDeleteBindings();
+    doReturn(false).when(config).isAllowDeleteTopics();
 
-    HashMap<String, String> cliOps = new HashMap<>();
-    cliOps.put(BROKERS_OPTION, "");
-    cliOps.put(ALLOW_DELETE_OPTION, "false");
-
-    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
-
-    accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder, config);
-
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-    consumers.add(new Consumer("User:app2"));
-
-    Topic topicA = new TopicImpl("topicA");
-
-    Topology topology = buildTopology(consumers, singletonList(topicA));
-
-    List<TopologyAclBinding> bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
-
-    accessControlManager.apply(topology, plan);
-    plan.run();
-
-    verify(aclsBuilder, times(1))
-        .buildBindingsForConsumers(refEq(consumers), eq(topicA.toString()), eq(false));
-
-    consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-
-    bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
-
-    Topology newTopology = buildTopology(consumers, singletonList(topicA));
-
-    accessControlManager.apply(newTopology, plan);
-    plan.run();
-
-    List<TopologyAclBinding> bindingsToDelete =
-        returnAclsForConsumers(singletonList(new Consumer("User:app2")), topicA.getName());
-
-    verify(aclsProvider, times(0)).clearBindings(new HashSet<>(bindingsToDelete));
+    verifyNoAclsDeleted();
   }
 
   @Test
   public void testBindingsDeleteWithSpecificConfigEnabled() throws IOException {
+    doReturn(true).when(config).isAllowDeleteBindings();
+    doReturn(false).when(config).isAllowDeleteTopics();
 
-    BackendController backendController = new BackendController();
-    backendController.load();
-    backendController.reset();
+    verifyAclsDelete();
+  }
+
+  private void verifyNoAclsDeleted() throws IOException {
+    BackendController backendController = initializeFileBackendController();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
+    accessControlManager =
+        new AccessControlManager(aclsProvider, new AclsBindingsBuilder(config), config);
 
-    Properties props = new Properties();
-    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, Arrays.asList("foo.", "_"));
-    props.put(ALLOW_DELETE_BINDINGS, "true");
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject()
+            .addTopic("topicA")
+            .addConsumer("User:app1")
+            .addConsumer("User:app2");
 
-    HashMap<String, String> cliOps = new HashMap<>();
-    cliOps.put(BROKERS_OPTION, "");
-    cliOps.put(ALLOW_DELETE_OPTION, "false");
+    accessControlManager.apply(builder.buildTopology(), plan);
+    plan.run();
 
-    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
+    verify(aclsProvider, times(1)).createBindings(any());
 
-    accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder, config);
+    builder.removeConsumer("User:app2");
 
-    List<Consumer> consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-    consumers.add(new Consumer("User:app2"));
+    Mockito.reset(aclsProvider);
+    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    accessControlManager.apply(builder.buildTopology(), plan);
+    plan.run();
 
-    Topic topicA = new TopicImpl("topicA");
+    verify(aclsProvider, times(0)).clearBindings(any());
+  }
 
-    Topology topology = buildTopology(consumers, singletonList(topicA));
+  private void verifyAclsDelete() throws IOException {
+    BackendController backendController = initializeFileBackendController();
+    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    accessControlManager =
+        new AccessControlManager(aclsProvider, new AclsBindingsBuilder(config), config);
 
-    List<TopologyAclBinding> bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
+    TestTopologyBuilder builder =
+        TestTopologyBuilder.createProject()
+            .addTopic("topicA")
+            .addConsumer("User:app1")
+            .addConsumer("User:app2");
 
+    accessControlManager.apply(builder.buildTopology(), plan);
+    plan.run();
+
+    verify(aclsProvider, times(1)).createBindings(any());
+
+    builder.removeConsumer("User:app2");
+
+    Mockito.reset(aclsProvider);
+    plan = ExecutionPlan.init(backendController, mockPrintStream);
+    Topology topology = builder.buildTopology();
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(aclsBuilder, times(1))
-        .buildBindingsForConsumers(refEq(consumers), eq(topicA.toString()), eq(false));
-
-    consumers = new ArrayList<>();
-    consumers.add(new Consumer("User:app1"));
-
-    bindings = returnAclsForConsumers(consumers, topicA.getName());
-    doReturn(bindings)
-        .when(aclsBuilder)
-        .buildBindingsForConsumers(any(), eq(topicA.toString()), eq(false));
-
-    Topology newTopology = buildTopology(consumers, singletonList(topicA));
-
-    accessControlManager.apply(newTopology, plan);
-    plan.run();
-
     List<TopologyAclBinding> bindingsToDelete =
-        returnAclsForConsumers(singletonList(new Consumer("User:app2")), topicA.getName());
+        returnAclsForConsumers(
+            singletonList(new Consumer("User:app2")), builder.getTopic("topicA").toString());
 
     verify(aclsProvider, times(1)).clearBindings(new HashSet<>(bindingsToDelete));
-  }
-
-  private Topology buildTopology(List<Consumer> consumers, List<Topic> topics) {
-
-    Project project = new ProjectImpl();
-    project.setConsumers(consumers);
-
-    for (Topic topic : topics) {
-      project.addTopic(topic);
-    }
-
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
-
-    return topology;
   }
 
   private List<TopologyAclBinding> returnAclsForConsumers(List<Consumer> consumers, String topic) {
@@ -687,5 +547,12 @@ public class AccessControlManagerTest {
         .addResource(ResourceType.GROUP, group, patternType)
         .addControlEntry("*", op, AclPermissionType.ALLOW)
         .build();
+  }
+
+  private BackendController initializeFileBackendController() throws IOException {
+    BackendController backendController = new BackendController();
+    backendController.load();
+    backendController.reset();
+    return backendController;
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/TestTopologyBuilder.java
+++ b/src/test/java/com/purbon/kafka/topology/TestTopologyBuilder.java
@@ -1,0 +1,108 @@
+package com.purbon.kafka.topology;
+
+import com.purbon.kafka.topology.model.Impl.ProjectImpl;
+import com.purbon.kafka.topology.model.Impl.TopicImpl;
+import com.purbon.kafka.topology.model.Impl.TopologyImpl;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.model.users.Consumer;
+import com.purbon.kafka.topology.model.users.Producer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TestTopologyBuilder {
+  private final Topology topology;
+  private final Project project;
+  private Set<Topic> topics = new HashSet<>();
+  private final Set<Consumer> consumers = new HashSet<>();
+  private final Set<Producer> producers = new HashSet<>();
+
+  public TestTopologyBuilder() {
+    this("ctx", "project");
+  }
+
+  public TestTopologyBuilder(String context, String projectName) {
+    topology = new TopologyImpl();
+    topology.setContext(context);
+    project = new ProjectImpl(projectName);
+    topology.addProject(project);
+  }
+
+  public static TestTopologyBuilder createProject() {
+    return new TestTopologyBuilder();
+  }
+
+  public static TestTopologyBuilder createProject(String context, String projectName) {
+    return new TestTopologyBuilder(context, projectName);
+  }
+
+  public Topology buildTopology() {
+    project.setTopics(new ArrayList<>(topics));
+    project.setConsumers(new ArrayList<>(consumers));
+    project.setProducers(new ArrayList<>(producers));
+    return topology;
+  }
+
+  public TestTopologyBuilder addTopic(String topicName) {
+    addTopic(new TopicImpl(topicName));
+    return this;
+  }
+
+  public TestTopologyBuilder addTopic(Topic topic) {
+    topics.add(topic);
+    return this;
+  }
+
+  @SuppressWarnings("unused")
+  public TestTopologyBuilder removeTopic(String topicName) {
+    topics =
+        topics.stream()
+            .filter(topic -> !topic.getName().equals(topicName))
+            .collect(Collectors.toSet());
+    return this;
+  }
+
+  public TestTopologyBuilder addConsumer(String user) {
+    consumers.add(new Consumer(user));
+    return this;
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public TestTopologyBuilder removeConsumer(String user) {
+    consumers.remove(new Consumer(user));
+    return this;
+  }
+
+  public TestTopologyBuilder addProducer(String user) {
+    producers.add(new Producer(user));
+    return this;
+  }
+
+  @SuppressWarnings("unused")
+  public TestTopologyBuilder removeProducer(String user) {
+    producers.remove(new Producer(user));
+    return this;
+  }
+
+  public Topic getTopic(String topicName) {
+    return topics.stream()
+        .filter(topic1 -> topic1.getName().equals(topicName))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("No topic named " + topicName));
+  }
+
+  public Set<Consumer> getConsumers() {
+    return consumers;
+  }
+
+  public Set<Producer> getProducers() {
+    return producers;
+  }
+
+  public Project getProject() {
+    return project;
+  }
+}


### PR DESCRIPTION
This fixes #167. Improved the acl delete tests as described and also changed some other tests to use the new test data/topology builder.