### PR TITLE
Adding ability to pass KTB options for the jvm or the KTB itself via an environment variable

### DIFF
--- a/src/main/scripts/kafka-topology-builder.sh
+++ b/src/main/scripts/kafka-topology-builder.sh
@@ -4,4 +4,4 @@ KAFKA_TOPOLOGY_BUILDER_HOME=/usr/local/kafka-topology-builder
 KTB_JAR=$KAFKA_TOPOLOGY_BUILDER_HOME/bin/kafka-topology-builder.jar
 JAVA_PATH=java
 
-$JAVA_PATH -jar $KTB_JAR "$@"
+$JAVA_PATH $JVM_OPTIONS -jar $KTB_JAR "$@"

--- a/src/main/scripts/kafka-topology-builder.sh
+++ b/src/main/scripts/kafka-topology-builder.sh
@@ -4,4 +4,8 @@ KAFKA_TOPOLOGY_BUILDER_HOME=/usr/local/kafka-topology-builder
 KTB_JAR=$KAFKA_TOPOLOGY_BUILDER_HOME/bin/kafka-topology-builder.jar
 JAVA_PATH=java
 
-$JAVA_PATH $JVM_OPTIONS -jar $KTB_JAR "$@"
+if [ -z "$KTB_OPTIONS" ]; then
+  KTB_OPTIONS=""
+fi
+
+$JAVA_PATH $KTB_OPTIONS -jar $KTB_JAR "$@"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Simple fix to add an environment variable to the startup script in the docker image. With this the user can pass JVM arguments via environment variables


* **What is the current behavior?** (You can also link to an open issue here)
Right now there is not way to pass arguments to the JVM


* **What is the new behavior (if this is a feature change)?**
With this change the user can just pass an environment variable with all the "-D" arguments required


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It should not since if the environment variable is not set it would just behave as it has always behaved


* **Other information**:
Opened issue #176 for this. 

**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING