### PR TITLE
Allow topic state bookkeeping from the cluster backend state system  

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -133,3 +133,21 @@ You can override this behaviour by setting the config below to `false`. And inst
 An example configuration will look like this:
 ::
     topology.connector.allow.topic.create=false
+
+Retrieve topic management state from local controlled view
+-----------
+
+By default since it's creation KTB has been retrieving the state of topics from the target cluster, this means pulling the actual view directly
+from there (AK cluster) using AdminClient. However, this is not optimal when multiple teams use KTB as a multi tenant tool.
+
+If you want to manage the current view of topics from the own KTB  cluster state subsystem, you should use this property.
+
+**Property**: *topology.state.topics.cluster.enabled*
+**Default value**: true
+
+This property is fow the time being true as default (backwards compatible), however the local management system for topics will become the
+default in 2.0 and in 3.0 the management using the target cluster will be completely removed.
+
+An example to use local topic management state will look like this:
+::
+    topology.state.topics.cluster.enabled=false

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -38,7 +38,7 @@ public class BackendController {
     this.topics = new HashSet<>();
   }
 
-  public void add(List<TopologyAclBinding> bindings) {
+  public void addBindings(List<TopologyAclBinding> bindings) {
     LOGGER.debug(String.format("Adding bindings %s to the backend", bindings));
     this.bindings.addAll(bindings);
   }
@@ -51,11 +51,6 @@ public class BackendController {
   public void addServiceAccounts(Set<ServiceAccount> serviceAccounts) {
     LOGGER.debug(String.format("Adding Service Accounts %s to the backend", serviceAccounts));
     this.serviceAccounts.addAll(serviceAccounts);
-  }
-
-  public void add(TopologyAclBinding binding) {
-    LOGGER.debug(String.format("Adding binding %s to the backend", binding));
-    this.bindings.add(binding);
   }
 
   public Set<ServiceAccount> getServiceAccounts() {

--- a/src/main/java/com/purbon/kafka/topology/BackendController.java
+++ b/src/main/java/com/purbon/kafka/topology/BackendController.java
@@ -23,6 +23,7 @@ public class BackendController {
   private static final String STORE_TYPE = "acls";
 
   private final Backend backend;
+  private Set<String> topics;
   private Set<TopologyAclBinding> bindings;
   private Set<ServiceAccount> serviceAccounts;
 
@@ -34,11 +35,17 @@ public class BackendController {
     this.backend = backend;
     this.bindings = new HashSet<>();
     this.serviceAccounts = new HashSet<>();
+    this.topics = new HashSet<>();
   }
 
   public void add(List<TopologyAclBinding> bindings) {
     LOGGER.debug(String.format("Adding bindings %s to the backend", bindings));
     this.bindings.addAll(bindings);
+  }
+
+  public void addTopics(Set<String> topics) {
+    LOGGER.debug(String.format("Adding topics %s to the backend", topics));
+    this.topics.addAll(topics);
   }
 
   public void addServiceAccounts(Set<ServiceAccount> serviceAccounts) {
@@ -59,6 +66,10 @@ public class BackendController {
     return bindings;
   }
 
+  public Set<String> getTopics() {
+    return topics;
+  }
+
   public void flushAndClose() {
     LOGGER.debug(String.format("Flushing the current state of %s, %s", STORE_TYPE, bindings));
     backend.createOrOpen(Mode.TRUNCATE);
@@ -66,6 +77,8 @@ public class BackendController {
     backend.saveBindings(bindings);
     backend.saveType("ServiceAccounts");
     backend.saveAccounts(serviceAccounts);
+    backend.saveType("Topics");
+    backend.saveTopics(topics);
     backend.close();
   }
 
@@ -74,15 +87,17 @@ public class BackendController {
     backend.createOrOpen();
     bindings.addAll(backend.loadBindings());
     serviceAccounts.addAll(backend.loadServiceAccounts());
+    topics.addAll(backend.loadTopics());
   }
 
   public void reset() {
     LOGGER.debug("Reset the bindings cache");
     bindings.clear();
     serviceAccounts.clear();
+    topics.clear();
   }
 
   public int size() {
-    return bindings.size() + serviceAccounts.size();
+    return bindings.size() + serviceAccounts.size() + topics.size();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
+++ b/src/main/java/com/purbon/kafka/topology/ExecutionPlan.java
@@ -71,7 +71,7 @@ public class ExecutionPlan {
     }
 
     backendController.reset();
-    backendController.add(new ArrayList<>(bindings));
+    backendController.addBindings(new ArrayList<>(bindings));
     backendController.addServiceAccounts(serviceAccounts);
     backendController.addTopics(topics);
     backendController.flushAndClose();

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -21,21 +21,19 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 
 public class TopologyBuilderConfig {
 
-  public static final String KAFKA_INTERNAL_TOPIC_PREFIXES = "kafka.internal.topic.prefixes";
-  public static final String ACCESS_CONTROL_IMPLEMENTATION_CLASS =
-      "topology.builder.access.control.class";
+  static final String KAFKA_INTERNAL_TOPIC_PREFIXES = "kafka.internal.topic.prefixes";
+  static final String ACCESS_CONTROL_IMPLEMENTATION_CLASS = "topology.builder.access.control.class";
 
-  public static final String ACCESS_CONTROL_DEFAULT_CLASS =
+  static final String ACCESS_CONTROL_DEFAULT_CLASS =
       "com.purbon.kafka.topology.roles.SimpleAclsProvider";
-  public static final String RBAC_ACCESS_CONTROL_CLASS =
-      "com.purbon.kafka.topology.roles.RBACProvider";
+  static final String RBAC_ACCESS_CONTROL_CLASS = "com.purbon.kafka.topology.roles.RBACProvider";
 
-  public static final String STATE_PROCESSOR_IMPLEMENTATION_CLASS =
+  private static final String STATE_PROCESSOR_IMPLEMENTATION_CLASS =
       "topology.builder.state.processor.class";
 
-  public static final String STATE_PROCESSOR_DEFAULT_CLASS =
+  static final String STATE_PROCESSOR_DEFAULT_CLASS =
       "com.purbon.kafka.topology.backend.FileBackend";
-  public static final String REDIS_STATE_PROCESSOR_CLASS =
+  static final String REDIS_STATE_PROCESSOR_CLASS =
       "com.purbon.kafka.topology.backend.RedisBackend";
 
   static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
@@ -65,16 +63,17 @@ public class TopologyBuilderConfig {
   static final String OPTIMIZED_ACLS_CONFIG = "topology.acls.optimized";
 
   static final String ALLOW_DELETE_TOPICS = "allow.delete.topics";
-  static final String ALLOW_DELETE_BINDINGS = "allow.delete.bindings";
-  static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
+  private static final String ALLOW_DELETE_BINDINGS = "allow.delete.bindings";
+  private static final String ALLOW_DELETE_PRINCIPALS = "allow.delete.principals";
 
-  public static final String CCLOUD_ENV_CONFIG = "ccloud.environment";
+  static final String CCLOUD_ENV_CONFIG = "ccloud.environment";
 
   static final String TOPOLOGY_EXPERIMENTAL_ENABLED_CONFIG = "topology.features.experimental";
   static final String TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG =
       "topology.translation.principal.enabled";
 
-  static final String TOPOLOGY_TOPIC_STATE_FROM_CLUSTER = "topology.state.topics.cluster.enabled";
+  public static final String TOPOLOGY_TOPIC_STATE_FROM_CLUSTER =
+      "topology.state.topics.cluster.enabled";
 
   private final Map<String, String> cliParams;
   private Config config;

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -74,6 +74,8 @@ public class TopologyBuilderConfig {
   static final String TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG =
       "topology.translation.principal.enabled";
 
+  static final String TOPOLOGY_TOPIC_STATE_FROM_CLUSTER = "topology.state.topics.cluster.enabled";
+
   private final Map<String, String> cliParams;
   private Config config;
 
@@ -326,5 +328,9 @@ public class TopologyBuilderConfig {
 
   public boolean enabledPrincipalTranslation() {
     return config.getBoolean(TOPOLOGY_PRINCIPAL_TRANSLATION_ENABLED_CONFIG);
+  }
+
+  public boolean fetchStateFromTheCluster() {
+    return config.getBoolean(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/actions/topics/DeleteTopics.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/topics/DeleteTopics.java
@@ -34,4 +34,8 @@ public class DeleteTopics extends BaseAction {
     map.put("topics", topicsToBeDeleted);
     return map;
   }
+
+  public List<String> getTopicsToBeDeleted() {
+    return topicsToBeDeleted;
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
@@ -35,6 +35,10 @@ public class SyncTopicAction extends BaseAction {
     this.schemaRegistryManager = schemaRegistryManager;
   }
 
+  public String getTopic() {
+    return fullTopicName;
+  }
+
   @Override
   public void run() throws IOException {
     syncTopic(topic, fullTopicName, listOfTopics);

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -16,11 +16,15 @@ public interface Backend {
 
   Set<TopologyAclBinding> loadBindings() throws IOException;
 
+  Set<String> loadTopics() throws IOException;
+
   void saveType(String type);
 
   void saveBindings(Set<TopologyAclBinding> bindings);
 
   void saveAccounts(Set<ServiceAccount> accounts);
+
+  void saveTopics(Set<String> topics);
 
   void close();
 }

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -28,9 +28,9 @@ public class FileBackend implements Backend {
 
   private static final Logger LOGGER = LogManager.getLogger(FileBackend.class);
   public static final String STATE_FILE_NAME = ".cluster-state";
-  public static final String SERVICE_ACCOUNTS_TAG = "ServiceAccounts";
-  public static final String TOPICS_TAG = "Topics";
-  public static final String ACLS_TAG = "acls";
+  static final String SERVICE_ACCOUNTS_TAG = "ServiceAccounts";
+  static final String TOPICS_TAG = "Topics";
+  static final String ACLS_TAG = "acls";
 
   private RandomAccessFile writer;
   private String expression =
@@ -94,19 +94,6 @@ public class FileBackend implements Backend {
   }
 
   public Set<ServiceAccount> loadServiceAccounts() throws IOException {
-    /* if (writer == null) {
-          throw new IOException("state file does not exist");
-        }
-        Set<ServiceAccount> accounts = new HashSet<>();
-        BufferedReader in = openLocalStateFile();
-        String line = moveFileToTag(SERVICE_ACCOUNTS_TAG, in);
-        if (line != null && line.equalsIgnoreCase(SERVICE_ACCOUNTS_TAG)) {
-          while ((line = in.readLine()) != null && !foundAControlTag(line)) {
-            ServiceAccount account = (ServiceAccount) JSON.toObject(line, ServiceAccount.class);
-            accounts.add(account);
-          }
-        }
-    */
     return loadItemsFromFile(
             SERVICE_ACCOUNTS_TAG,
             line -> {

--- a/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
@@ -48,15 +48,8 @@ public class RedisBackend implements Backend {
   }
 
   @Override
-  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
-    return new HashSet<>();
-  }
-
-  @Override
   public Set<TopologyAclBinding> loadBindings() throws IOException {
-    if (!jedis.isConnected()) {
-      createOrOpen();
-    }
+    connectIfNeed();
 
     Set<TopologyAclBinding> bindings = new HashSet<>();
     String type = jedis.get(KAFKA_TOPOLOGY_BUILDER_TYPE);
@@ -69,6 +62,22 @@ public class RedisBackend implements Backend {
     }
 
     return bindings;
+  }
+
+  private void connectIfNeed() {
+    if (!jedis.isConnected()) {
+      createOrOpen();
+    }
+  }
+
+  @Override
+  public Set<ServiceAccount> loadServiceAccounts() throws IOException {
+    return new HashSet<>();
+  }
+
+  @Override
+  public Set<String> loadTopics() throws IOException {
+    return new HashSet<>();
   }
 
   @Override
@@ -87,6 +96,9 @@ public class RedisBackend implements Backend {
 
   @Override
   public void saveAccounts(Set<ServiceAccount> accounts) {}
+
+  @Override
+  public void saveTopics(Set<String> topics) {}
 
   @Override
   public void close() {

--- a/src/main/java/com/purbon/kafka/topology/utils/JSON.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/JSON.java
@@ -2,12 +2,19 @@ package com.purbon.kafka.topology.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.util.List;
 import java.util.Map;
 
 public class JSON {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper;
+
+  static {
+    mapper = new ObjectMapper();
+    mapper.registerModule(new Jdk8Module());
+    mapper.findAndRegisterModules();
+  }
 
   public static Map<String, Object> toMap(String jsonString) throws JsonProcessingException {
     return mapper.readValue(jsonString, Map.class);

--- a/src/main/java/com/purbon/kafka/topology/utils/StreamUtils.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/StreamUtils.java
@@ -1,0 +1,19 @@
+package com.purbon.kafka.topology.utils;
+
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StreamUtils<T> {
+
+  private final Stream<T> stream;
+
+  public StreamUtils(Stream<T> stream) {
+    this.stream = stream;
+  }
+
+  public Set<T> filterAsSet(Predicate<T> p) {
+    return stream.filter(p).collect(Collectors.toSet());
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,6 +41,11 @@ topology {
       topic.create = true
     }
   }
+  state {
+     topics {
+        cluster.enabled = true
+     }
+  }
 }
 
 schema {

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -68,7 +68,7 @@ public class AccessControlManagerTest {
     TestUtils.deleteStateFile();
     plan = ExecutionPlan.init(backendController, mockPrintStream);
     accessControlManager = new AccessControlManager(aclsProvider, aclsBuilder);
-    doNothing().when(backendController).add(Matchers.anyList());
+    doNothing().when(backendController).addBindings(Matchers.anyList());
     doNothing().when(backendController).flushAndClose();
   }
 

--- a/src/test/java/com/purbon/kafka/topology/BackendControllerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/BackendControllerTest.java
@@ -50,7 +50,7 @@ public class BackendControllerTest {
         TopologyAclBinding.build(
             ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
 
-    backend.add(binding);
+    backend.addBindings(Collections.singletonList(binding));
 
     assertEquals(1, backend.size());
   }
@@ -66,7 +66,7 @@ public class BackendControllerTest {
 
     ServiceAccount serviceAccount = new ServiceAccount(1, "name", "description");
 
-    backend.add(Collections.singletonList(binding));
+    backend.addBindings(Collections.singletonList(binding));
     backend.addServiceAccounts(Collections.singleton(serviceAccount));
 
     backend.flushAndClose();
@@ -90,7 +90,7 @@ public class BackendControllerTest {
         TopologyAclBinding.build(
             ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
 
-    backend.add(Collections.singletonList(binding));
+    backend.addBindings(Collections.singletonList(binding));
     backend.addTopics(Collections.singleton(topic.getName()));
 
     backend.flushAndClose();

--- a/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
@@ -1,13 +1,24 @@
 package com.purbon.kafka.topology;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.purbon.kafka.topology.actions.access.ClearBindings;
 import com.purbon.kafka.topology.actions.access.CreateBindings;
+import com.purbon.kafka.topology.actions.topics.DeleteTopics;
+import com.purbon.kafka.topology.actions.topics.SyncTopicAction;
+import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.Impl.ProjectImpl;
+import com.purbon.kafka.topology.model.Impl.TopicImpl;
+import com.purbon.kafka.topology.model.Impl.TopologyImpl;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import com.purbon.kafka.topology.schemas.SchemaRegistryManager;
 import com.purbon.kafka.topology.utils.TestUtils;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -24,14 +35,20 @@ import org.mockito.junit.MockitoRule;
 
 public class ExecutionPlanTest {
 
-  ExecutionPlan plan;
-  BackendController backendController;
+  private ExecutionPlan plan;
+  private BackendController backendController;
 
   @Mock PrintStream mockPrintStream;
 
   @Mock SimpleAclsProvider aclsProvider;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  TopologyBuilderAdminClient adminClient;
+
+  @Mock
+  SchemaRegistryManager schemaRegistryManager;
 
   @Before
   public void before() throws IOException {
@@ -76,7 +93,7 @@ public class ExecutionPlanTest {
     BackendController backendController = new BackendController();
     ExecutionPlan plan = ExecutionPlan.init(backendController, mockPrintStream);
 
-    bindings = new HashSet<>(Arrays.asList(binding2));
+    bindings = new HashSet<>(singletonList(binding2));
     ClearBindings clearBindingsAction = new ClearBindings(aclsProvider, bindings);
 
     plan.add(clearBindingsAction);
@@ -89,5 +106,74 @@ public class ExecutionPlanTest {
     backendController = new BackendController();
     backendController.load();
     assertEquals(1, backendController.size());
+  }
+
+  @Test
+  public void addTopicsTest() throws IOException {
+    Topology topology = buildTopologyForTest();
+    Topic topicFoo = topology.getProjects().get(0).getTopics().get(0);
+    Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
+    Set<String> listOfTopics = new HashSet<>();
+
+    SyncTopicAction addTopicAction1 = new SyncTopicAction(adminClient,
+        schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+
+    SyncTopicAction addTopicAction2 = new SyncTopicAction(adminClient,
+        schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+
+    plan.add(addTopicAction1);
+    plan.add(addTopicAction2);
+
+    plan.run();
+
+    verify(adminClient, times(1)).createTopic(topicFoo, topicFoo.toString());
+    verify(adminClient, times(1)).createTopic(topicBar, topicBar.toString());
+    assertEquals(2, backendController.size());
+  }
+
+  @Test
+  public void deleteTopicsPreviouslyAddedTest() throws IOException {
+    Topology topology = buildTopologyForTest();
+    Topic topicFoo = topology.getProjects().get(0).getTopics().get(0);
+    Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
+    Set<String> listOfTopics = new HashSet<>();
+
+    SyncTopicAction addTopicAction1 = new SyncTopicAction(adminClient,
+        schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+
+    SyncTopicAction addTopicAction2 = new SyncTopicAction(adminClient,
+        schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+
+    plan.add(addTopicAction1);
+    plan.add(addTopicAction2);
+
+    plan.run();
+
+    verify(adminClient, times(1)).createTopic(topicFoo, topicFoo.toString());
+    verify(adminClient, times(1)).createTopic(topicBar, topicBar.toString());
+    assertEquals(2, backendController.size());
+
+    BackendController backendController = new BackendController();
+    ExecutionPlan plan = ExecutionPlan.init(backendController, mockPrintStream);
+
+    DeleteTopics deleteTopicsAction = new DeleteTopics(adminClient, singletonList(topicFoo.toString()));
+    plan.add(deleteTopicsAction);
+
+    plan.run();
+
+    verify(adminClient, times(1)).deleteTopics(singletonList(topicFoo.toString()));
+    assertEquals(1, backendController.size());
+  }
+
+  private Topology buildTopologyForTest() {
+    Topology topology = new TopologyImpl();
+    topology.setContext("context");
+    Project project = new ProjectImpl("project");
+    topology.setProjects(singletonList(project));
+
+    Topic topic = new TopicImpl("foo");
+    Topic topicBar = new TopicImpl("bar");
+    project.setTopics(Arrays.asList(topic, topicBar));
+    return topology;
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ExecutionPlanTest.java
@@ -44,11 +44,9 @@ public class ExecutionPlanTest {
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  @Mock
-  TopologyBuilderAdminClient adminClient;
+  @Mock TopologyBuilderAdminClient adminClient;
 
-  @Mock
-  SchemaRegistryManager schemaRegistryManager;
+  @Mock SchemaRegistryManager schemaRegistryManager;
 
   @Before
   public void before() throws IOException {
@@ -115,11 +113,13 @@ public class ExecutionPlanTest {
     Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
     Set<String> listOfTopics = new HashSet<>();
 
-    SyncTopicAction addTopicAction1 = new SyncTopicAction(adminClient,
-        schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+    SyncTopicAction addTopicAction1 =
+        new SyncTopicAction(
+            adminClient, schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
 
-    SyncTopicAction addTopicAction2 = new SyncTopicAction(adminClient,
-        schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+    SyncTopicAction addTopicAction2 =
+        new SyncTopicAction(
+            adminClient, schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
 
     plan.add(addTopicAction1);
     plan.add(addTopicAction2);
@@ -138,11 +138,13 @@ public class ExecutionPlanTest {
     Topic topicBar = topology.getProjects().get(0).getTopics().get(1);
     Set<String> listOfTopics = new HashSet<>();
 
-    SyncTopicAction addTopicAction1 = new SyncTopicAction(adminClient,
-        schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
+    SyncTopicAction addTopicAction1 =
+        new SyncTopicAction(
+            adminClient, schemaRegistryManager, topicFoo, topicFoo.toString(), listOfTopics);
 
-    SyncTopicAction addTopicAction2 = new SyncTopicAction(adminClient,
-        schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
+    SyncTopicAction addTopicAction2 =
+        new SyncTopicAction(
+            adminClient, schemaRegistryManager, topicBar, topicBar.toString(), listOfTopics);
 
     plan.add(addTopicAction1);
     plan.add(addTopicAction2);
@@ -156,7 +158,8 @@ public class ExecutionPlanTest {
     BackendController backendController = new BackendController();
     ExecutionPlan plan = ExecutionPlan.init(backendController, mockPrintStream);
 
-    DeleteTopics deleteTopicsAction = new DeleteTopics(adminClient, singletonList(topicFoo.toString()));
+    DeleteTopics deleteTopicsAction =
+        new DeleteTopics(adminClient, singletonList(topicFoo.toString()));
     plan.add(deleteTopicsAction);
 
     plan.run();

--- a/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
@@ -5,6 +5,7 @@ import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
 import static com.purbon.kafka.topology.TopicManager.NUM_PARTITIONS;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.ALLOW_DELETE_TOPICS;
 import static com.purbon.kafka.topology.TopologyBuilderConfig.KAFKA_INTERNAL_TOPIC_PREFIXES;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.TOPOLOGY_TOPIC_STATE_FROM_CLUSTER;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -19,6 +20,8 @@ import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.schemas.SchemaRegistryManager;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.Before;
@@ -34,21 +37,33 @@ public class TopicManagerTest {
 
   @Mock SchemaRegistryManager schemaRegistryManager;
 
-  @Mock BackendController backendController;
+  BackendController backendController;
   ExecutionPlan plan;
+
   @Mock PrintStream outputStream;
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   private TopicManager topicManager;
   private HashMap<String, String> cliOps;
+  private Properties props;
+  private TopologyBuilderConfig config;
 
   @Before
   public void setup() throws IOException {
+
+    Files.deleteIfExists(Paths.get(".cluster-state"));
+    backendController = new BackendController();
+
     cliOps = new HashMap<>();
     cliOps.put(BROKERS_OPTION, "");
+    props = new Properties();
+    props.put(TOPOLOGY_TOPIC_STATE_FROM_CLUSTER, "false");
+
     plan = ExecutionPlan.init(backendController, System.out);
-    topicManager = new TopicManager(adminClient, schemaRegistryManager);
+
+    config = new TopologyBuilderConfig(cliOps, props);
+    topicManager = new TopicManager(adminClient, schemaRegistryManager, config);
   }
 
   @Test
@@ -73,23 +88,40 @@ public class TopicManagerTest {
   @Test
   public void topicUpdateTest() throws IOException {
 
+    Topology topology = new TopologyImpl();
     Project project = new ProjectImpl("project");
+    topology.addProject(project);
+
     Topic topicA = new TopicImpl("topicA");
     project.addTopic(topicA);
     Topic topicB = new TopicImpl("topicB");
-    topicB.getConfig().put(NUM_PARTITIONS, "12");
     project.addTopic(topicB);
-    Topology topology = new TopologyImpl();
-    topology.addProject(project);
-
-    Set<String> dummyTopicList = new HashSet<>();
-    dummyTopicList.add(topicB.toString());
-    when(adminClient.listApplicationTopics()).thenReturn(dummyTopicList);
 
     topicManager.apply(topology, plan);
     plan.run();
 
     verify(adminClient, times(1)).createTopic(topicA, topicA.toString());
+    verify(adminClient, times(1)).createTopic(topicB, topicB.toString());
+
+    ExecutionPlan plan = ExecutionPlan.init(backendController, System.out);
+    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
+    TopicManager topicManager = new TopicManager(adminClient, schemaRegistryManager, config);
+
+    topology = new TopologyImpl();
+    project = new ProjectImpl("project");
+    topology.addProject(project);
+
+    topicA = new TopicImpl("topicA");
+    project.addTopic(topicA);
+    topicB = new TopicImpl("topicB");
+    topicB.getConfig().put(NUM_PARTITIONS, "12");
+    project.addTopic(topicB);
+
+    topicManager.apply(topology, plan);
+    plan.run();
+
+    verify(adminClient, times(0)).createTopic(topicA, topicA.toString());
+    verify(adminClient, times(0)).createTopic(topicB, topicB.toString());
     verify(adminClient, times(1)).updateTopicConfig(topicB, topicB.toString());
     verify(adminClient, times(1)).getPartitionCount(topicB.toString());
     verify(adminClient, times(1)).updatePartitionCount(topicB, topicB.toString());

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderAdminClientTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderAdminClientTest.java
@@ -73,7 +73,7 @@ public class TopologyBuilderAdminClientTest {
 
     plan = ExecutionPlan.init(backendController, System.out);
 
-    doNothing().when(backendController).add(Matchers.anyList());
+    doNothing().when(backendController).addBindings(Matchers.anyList());
     doNothing().when(backendController).flushAndClose();
 
     doReturn("foo").when(config).getConfluentCommandTopic();

--- a/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/FileBackendTest.java
@@ -1,0 +1,79 @@
+package com.purbon.kafka.topology.backend;
+
+import static com.purbon.kafka.topology.backend.FileBackend.ACLS_TAG;
+import static com.purbon.kafka.topology.backend.FileBackend.SERVICE_ACCOUNTS_TAG;
+import static com.purbon.kafka.topology.backend.FileBackend.STATE_FILE_NAME;
+import static com.purbon.kafka.topology.backend.FileBackend.TOPICS_TAG;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.purbon.kafka.topology.BackendController.Mode;
+import com.purbon.kafka.topology.model.Impl.ProjectImpl;
+import com.purbon.kafka.topology.model.Impl.TopicImpl;
+import com.purbon.kafka.topology.model.Impl.TopologyImpl;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.Topology;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileBackendTest {
+
+  private FileBackend backend;
+
+  @Before
+  public void setup() {
+    backend = new FileBackend();
+  }
+
+  @After
+  public void after() throws IOException {
+    Files.deleteIfExists(Paths.get(STATE_FILE_NAME));
+  }
+
+  @Test
+  public void testStoreAndLoadBindingsAndTopics() throws IOException {
+    TopologyAclBinding binding =
+        TopologyAclBinding.build(
+            ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
+
+    Topology topology = new TopologyImpl();
+    topology.setContext("context");
+    Project project = new ProjectImpl("project");
+    topology.setProjects(singletonList(project));
+
+    Topic topic = new TopicImpl("foo");
+    Topic topicBar = new TopicImpl("bar");
+    project.setTopics(Arrays.asList(topic, topicBar));
+
+    backend.createOrOpen(Mode.TRUNCATE);
+    backend.saveType(ACLS_TAG);
+    backend.saveBindings(Collections.singleton(binding));
+    backend.saveType(SERVICE_ACCOUNTS_TAG);
+    backend.saveType(TOPICS_TAG);
+    backend.saveTopics(new HashSet<>(Arrays.asList(topic.toString(), topicBar.toString())));
+    backend.close();
+
+    backend = new FileBackend();
+    backend.createOrOpen();
+
+    Set<TopologyAclBinding> bindings = backend.loadBindings();
+    Set<String> topics = backend.loadTopics();
+
+    assertThat(bindings).hasSize(1);
+    assertThat(bindings).contains(binding);
+    assertThat(topics).hasSize(2);
+    assertThat(topics).contains(topic.toString());
+    assertThat(topics).contains(topicBar.toString());
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
@@ -110,7 +110,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     plan.run();
 
     // this method is call twice, once for consumers and one for producers
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifyConsumerAcls(consumers, topicA.toString());
   }
@@ -134,7 +134,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     plan.run();
 
     // this method is call twice, once for consumers and one for consumers
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifyProducerAcls(producers, topicA.toString());
   }
@@ -158,7 +158,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifyKStreamsAcls(app);
   }
@@ -181,7 +181,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifyConnectAcls(connector);
   }
@@ -215,7 +215,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifySchemaRegistryAcls(platform);
   }
@@ -241,7 +241,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
     verifyControlCenterAcls(platform);
   }
@@ -266,7 +266,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
 
     verifyKafkaClusterACLs(platform);
@@ -292,7 +292,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
     accessControlManager.apply(topology, plan);
     plan.run();
 
-    verify(cs, times(1)).add(anyList());
+    verify(cs, times(1)).addBindings(anyList());
     verify(cs, times(1)).flushAndClose();
 
     verifyConnectClusterACLs(platform);

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/DefaultBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/DefaultBackendIT.java
@@ -39,7 +39,7 @@ public class DefaultBackendIT {
 
     Set<ServiceAccount> accounts = new HashSet<>(Arrays.asList(serviceAccount, serviceAccount2));
 
-    backend.add(Collections.singletonList(binding));
+    backend.addBindings(Collections.singletonList(binding));
     backend.addServiceAccounts(accounts);
     backend.flushAndClose();
 
@@ -60,7 +60,7 @@ public class DefaultBackendIT {
         TopologyAclBinding.build(
             ResourceType.CLUSTER.name(), "Topic", "host", "op", "principal", "LITERAL");
 
-    backend.add(Collections.singletonList(binding));
+    backend.addBindings(Collections.singletonList(binding));
     backend.flushAndClose();
 
     // reopen a new connection


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)

As of now the KTB retrieve the topic status (what has been created) directly from the cluster. There is an option to filter out what the user does not want to consider, however in a more multi tenant scenario, users want to control only what is managed by each of the KTB instances and the number can be bigger.


* **What is the new behavior (if this is a feature change)?**

We will keep the current behaviour as default till the release of 2.0, however, users would have the option to store the managed topics in the status backends. The use of status backends will be the default from 2.0 on.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not for now, but will introduce it in 2.0. This behaviour should be noted so it is not forgotten in the 2.0 release.

* **Other information**:


**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING