### PR TITLE
Add ability to use the name as the end topic name

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
@@ -94,6 +94,7 @@ public class TopicImpl implements Topic, Cloneable {
     this.dataType = dataType;
     this.config = config;
     this.schemas = new ArrayList<>();
+    this.context = new HashMap<>();
     this.replicationFactor = 0;
     this.partitionCount = 0;
     this.appConfig = appConfig;
@@ -133,6 +134,8 @@ public class TopicImpl implements Topic, Cloneable {
     switch (appConfig.getTopicPrefixFormat()) {
       case "default":
         return defaultTopicStructureString(projectPrefix);
+      case "name":
+        return name;
       default:
         return patternBasedTopicNameStructureString();
     }


### PR DESCRIPTION
Whilst it is possible to use a pattern like {{ topic }} when other tooling is being used like ansible there is a collision with {{ }} as it also uses jinja templating.