### PR TITLE
Support topology validations with fully qualified class names as configuration values (backwards compatible)

### DIFF
--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -104,24 +104,27 @@ An example configuration might look like this:
     kafka.internal.topic.prefixes.1=topicPrefixA
     kafka.internal.topic.prefixes.2=topicPrefixB
 
-Topology level validations
+Topology validations
 -----------
 
-It is now possible to define a list of validations to be applied to the desired Topology file.
+It is possible to define a list of validations to be applied to the topology files.
 
-As a user you can list the validations to be applied using the configuration property:
+As a user you can list the validation classes to be applied using the configuration property:
 
 - **Property**: *topology.validations*
 
-This property accepts the list of validations available in the class path.
+This property accepts a list of validation classes available in the class path. Use the fully qualified class name.
 They will be applied in sequence as defined.
+You will find included KTB validations in the package 'com.purbon.kafka.topology.validation'.
 
 An example configuration might look like this:
 ::
-    topology.validations.0=topology.CamelCaseNameFormatValidation
-    topology.validations.1=topic.PartitionNumberValidation
+    topology.validations.0=com.purbon.kafka.topology.validation.topology.CamelCaseNameFormatValidation
+    topology.validations.1=com.purbon.kafka.topology.validation.topic.PartitionNumberValidation
 
-Users can pull custom validation available from the class path.
+You can also create your own custom validations. The validations must implement one of these interfaces:
+- com.purbon.kafka.topology.validation.TopologyValidation
+- com.purbon.kafka.topology.validation.TopicValidation
 
 Prevent ACL for topic creation for connector principal
 -----------

--- a/src/main/java/com/purbon/kafka/topology/TopologyValidator.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyValidator.java
@@ -81,11 +81,10 @@ public class TopologyValidator {
         .map(
             validationClass -> {
               try {
-                Class<?> clazz;
-                clazz = getValidationClazz(validationClass);
+                Class<?> clazz = getValidationClazz(validationClass);
                 if (clazz == null) {
-                  String deprecatedValidationClassConfig = classPrefix + validationClass;
-                  clazz = getValidationClazz(deprecatedValidationClassConfig);
+                  String deprecatedClassNameFromPrefix = classPrefix + validationClass;
+                  clazz = getValidationClazz(deprecatedClassNameFromPrefix);
                   if (clazz != null) {
                     LOGGER.warn(
                         "Deprecation warning: Specifying validations in the config without using the "

--- a/src/main/java/com/purbon/kafka/topology/roles/CCloudAclsProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/CCloudAclsProvider.java
@@ -86,11 +86,12 @@ public class CCloudAclsProvider extends SimpleAclsProvider implements AccessCont
   private TopologyAclBinding convertToConfluentCloudId(
       Map<String, ServiceAccount> serviceAccounts, TopologyAclBinding binding) {
     if (binding.asAclBinding().isPresent()) {
-      AclBinding aclBinding = convertToConfluentCloudId(serviceAccounts, binding.asAclBinding().get());
+      AclBinding aclBinding =
+          convertToConfluentCloudId(serviceAccounts, binding.asAclBinding().get());
       return aclBinding == null ? null : new TopologyAclBinding(aclBinding);
     } else {
       Integer id = getId(serviceAccounts, binding.getPrincipal());
-      return id == null ? null :  getTopologyAclBinding(binding, "User:" + id);
+      return id == null ? null : getTopologyAclBinding(binding, "User:" + id);
     }
   }
 
@@ -119,18 +120,19 @@ public class CCloudAclsProvider extends SimpleAclsProvider implements AccessCont
 
   private AclBinding getAclBinding(AclBinding aclBinding, String principle) {
     AccessControlEntry entry = aclBinding.entry();
-    AccessControlEntry accessControlEntry = new AccessControlEntry(principle, entry.host(), entry.operation(), entry.permissionType());
+    AccessControlEntry accessControlEntry =
+        new AccessControlEntry(principle, entry.host(), entry.operation(), entry.permissionType());
     return new AclBinding(aclBinding.pattern(), accessControlEntry);
   }
 
   private TopologyAclBinding getTopologyAclBinding(TopologyAclBinding binding, String principle) {
     return new TopologyAclBinding(
-            binding.getResourceType(),
-            binding.getResourceName(),
-            binding.getHost(),
-            binding.getOperation(),
-            principle,
-            binding.getPattern());
+        binding.getResourceType(),
+        binding.getResourceName(),
+        binding.getHost(),
+        binding.getOperation(),
+        principle,
+        binding.getPattern());
   }
 
   private Integer getId(Map<String, ServiceAccount> serviceAccounts, String name) {


### PR DESCRIPTION
This fixes #201. 

In addition the following improvements have been done:
- Fail on validation class not found in class path. KTB should not preceed with processing in this case.

* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature improvement.

* **What is the current behavior?** (You can also link to an open issue here)
See #201.

* **What is the new behavior (if this is a feature change)?**
See #201.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Removing old, now deprecated behavior, should be handled in a later commit.
