### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
+++ b/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
@@ -28,8 +28,11 @@ public class CCloudCLI {
       stdout = run(cmd);
       ServiceAccount[] items = mapper.readValue(stdout, ServiceAccount[].class);
       return Arrays.stream(items).collect(Collectors.toMap(ServiceAccount::getName, i -> i));
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       handleError(stdout, e);
+	  return null;
+	} catch (InterruptedException e) {
+	  handleError(stdout, e);
       Thread.currentThread().interrupt();
       return null;
     }
@@ -40,8 +43,10 @@ public class CCloudCLI {
     String stdout = "";
     try {
       stdout = run(cmd);
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       handleError(stdout, e);
+	} catch (InterruptedException e) {
+	  handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
   }
@@ -62,8 +67,10 @@ public class CCloudCLI {
     try {
       stdout = run(cmd);
       sa = mapper.readValue(stdout, ServiceAccount.class);
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       handleError(stdout, e);
+	} catch (InterruptedException e) {
+	  handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
     return sa;
@@ -74,8 +81,10 @@ public class CCloudCLI {
     String stdout = "";
     try {
       stdout = run(cmd);
-    } catch (IOException | InterruptedException e) {
+    } catch (IOException e) {
       handleError(stdout, e);
+	} catch (InterruptedException e) {
+	  handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
   }

--- a/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
+++ b/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
@@ -30,9 +30,9 @@ public class CCloudCLI {
       return Arrays.stream(items).collect(Collectors.toMap(ServiceAccount::getName, i -> i));
     } catch (IOException e) {
       handleError(stdout, e);
-	  return null;
-	} catch (InterruptedException e) {
-	  handleError(stdout, e);
+      return null;
+    } catch (InterruptedException e) {
+      handleError(stdout, e);
       Thread.currentThread().interrupt();
       return null;
     }
@@ -45,23 +45,23 @@ public class CCloudCLI {
       stdout = run(cmd);
     } catch (IOException e) {
       handleError(stdout, e);
-	} catch (InterruptedException e) {
-	  handleError(stdout, e);
+    } catch (InterruptedException e) {
+      handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
   }
 
   public ServiceAccount newServiceAccount(String name, String description) throws IOException {
     List<String> cmd =
-        Arrays.asList(
-            "ccloud",
-            "service-account",
-            "create",
-            name,
-            "--description",
-            description,
-            "--output",
-            "json");
+      Arrays.asList(
+	  "ccloud",
+	  "service-account",
+	  "create",
+	  name,
+	  "--description",
+	  description,
+	  "--output",
+	  "json");
     String stdout = "";
     ServiceAccount sa = null;
     try {
@@ -69,8 +69,8 @@ public class CCloudCLI {
       sa = mapper.readValue(stdout, ServiceAccount.class);
     } catch (IOException e) {
       handleError(stdout, e);
-	} catch (InterruptedException e) {
-	  handleError(stdout, e);
+    } catch (InterruptedException e) {
+      handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
     return sa;
@@ -83,8 +83,8 @@ public class CCloudCLI {
       stdout = run(cmd);
     } catch (IOException e) {
       handleError(stdout, e);
-	} catch (InterruptedException e) {
-	  handleError(stdout, e);
+    } catch (InterruptedException e) {
+      handleError(stdout, e);
       Thread.currentThread().interrupt();
     }
   }

--- a/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
+++ b/src/main/java/com/purbon/kafka/topology/api/ccloud/CCloudCLI.java
@@ -30,6 +30,7 @@ public class CCloudCLI {
       return Arrays.stream(items).collect(Collectors.toMap(ServiceAccount::getName, i -> i));
     } catch (IOException | InterruptedException e) {
       handleError(stdout, e);
+      Thread.currentThread().interrupt();
       return null;
     }
   }
@@ -41,6 +42,7 @@ public class CCloudCLI {
       stdout = run(cmd);
     } catch (IOException | InterruptedException e) {
       handleError(stdout, e);
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -62,6 +64,7 @@ public class CCloudCLI {
       sa = mapper.readValue(stdout, ServiceAccount.class);
     } catch (IOException | InterruptedException e) {
       handleError(stdout, e);
+      Thread.currentThread().interrupt();
     }
     return sa;
   }
@@ -73,6 +76,7 @@ public class CCloudCLI {
       stdout = run(cmd);
     } catch (IOException | InterruptedException e) {
       handleError(stdout, e);
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).