### PR TITLE
[Sonar 2095] Fix, resources should be closed

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -75,23 +75,23 @@ public class FileBackend implements Backend {
     Path filePath = Paths.get(uri);
     Set<TopologyAclBinding> bindings = new LinkedHashSet<>();
     try (BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()))) {
-		String type = in.readLine();
-		String line = null;
-		while ((line = in.readLine()) != null) {
-		  TopologyAclBinding binding = null;
-		  if (line.equalsIgnoreCase("ServiceAccounts")) {
-			// process service accounts, should break from here.
-			break;
-		  }
-		  if (type.equalsIgnoreCase(ACLS_TAG)) {
-			binding = buildAclBinding(line);
-		  } else {
-			throw new IOException("Binding type ( " + type + " )not supported.");
-		  }
-		  bindings.add(binding);
-		}
-		return bindings;
+	String type = in.readLine();
+	String line = null;
+	while ((line = in.readLine()) != null) {
+	  TopologyAclBinding binding = null;
+	  if (line.equalsIgnoreCase("ServiceAccounts")) {
+		// process service accounts, should break from here.
+		break;
+	  }
+	  if (type.equalsIgnoreCase(ACLS_TAG)) {
+		binding = buildAclBinding(line);
+	  } else {
+		throw new IOException("Binding type ( " + type + " )not supported.");
+	  }
+	  bindings.add(binding);
 	}
+	return bindings;
+    }
   }
 
   public Set<ServiceAccount> loadServiceAccounts() throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -74,23 +74,24 @@ public class FileBackend implements Backend {
   public Set<TopologyAclBinding> load(URI uri) throws IOException {
     Path filePath = Paths.get(uri);
     Set<TopologyAclBinding> bindings = new LinkedHashSet<>();
-    BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()));
-    String type = in.readLine();
-    String line = null;
-    while ((line = in.readLine()) != null) {
-      TopologyAclBinding binding = null;
-      if (line.equalsIgnoreCase("ServiceAccounts")) {
-        // process service accounts, should break from here.
-        break;
-      }
-      if (type.equalsIgnoreCase(ACLS_TAG)) {
-        binding = buildAclBinding(line);
-      } else {
-        throw new IOException("Binding type ( " + type + " )not supported.");
-      }
-      bindings.add(binding);
-    }
-    return bindings;
+    try (BufferedReader in = new BufferedReader(new FileReader(filePath.toFile()))) {
+		String type = in.readLine();
+		String line = null;
+		while ((line = in.readLine()) != null) {
+		  TopologyAclBinding binding = null;
+		  if (line.equalsIgnoreCase("ServiceAccounts")) {
+			// process service accounts, should break from here.
+			break;
+		  }
+		  if (type.equalsIgnoreCase(ACLS_TAG)) {
+			binding = buildAclBinding(line);
+		  } else {
+			throw new IOException("Binding type ( " + type + " )not supported.");
+		  }
+		  bindings.add(binding);
+		}
+		return bindings;
+	}
   }
 
   public Set<ServiceAccount> loadServiceAccounts() throws IOException {


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).